### PR TITLE
feat: pretty print cli error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -166,17 +157,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
- "ansi_term 0.11.0",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -358,6 +375,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -647,6 +670,8 @@ name = "momento-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "clap",
+ "colored",
  "env_logger",
  "home",
  "log",
@@ -654,7 +679,6 @@ dependencies = [
  "momento",
  "reqwest",
  "serde",
- "structopt",
  "tokio",
  "toml",
  "tracing-subscriber",
@@ -726,6 +750,15 @@ name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
@@ -906,7 +939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "lazy_static",
  "log",
@@ -1268,33 +1301,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1338,12 +1347,9 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thread_local"
@@ -1614,7 +1620,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
@@ -1658,12 +1664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,12 +1686,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "^0.3.22"
+colored = "2.0.0"
+clap = { version = "3.0.10", features = ["derive"] }
 log = { version = "^0.4.14" }
 env_logger = { version = "^0.9.0" }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/src/commands/cache/cache.rs
+++ b/src/commands/cache/cache.rs
@@ -1,52 +1,58 @@
-use std::panic;
-
 use log::info;
 use momento::{cache::CacheClient, sdk::Momento};
 
-async fn get_momento_instance(auth_token: String) -> Momento {
+use crate::error::CliError;
+
+async fn get_momento_instance(auth_token: String) -> Result<Momento, CliError> {
     match Momento::new(auth_token).await {
-        Ok(m) => m,
-        Err(e) => panic!("{}", e),
+        Ok(m) => Ok(m),
+        Err(e) => Err(CliError { msg: e.to_string() }),
     }
 }
 
-async fn get_momento_cache(cache_name: String, auth_token: String) -> CacheClient {
-    let mut momento = get_momento_instance(auth_token).await;
+async fn get_momento_cache(
+    cache_name: String,
+    auth_token: String,
+) -> Result<CacheClient, CliError> {
+    let mut momento = get_momento_instance(auth_token).await?;
     match momento.get_cache(&cache_name, 100).await {
-        Ok(c) => c,
-        Err(e) => panic!("{}", e),
+        Ok(c) => Ok(c),
+        Err(e) => Err(CliError { msg: e.to_string() }),
     }
 }
 
-pub async fn create_cache(cache_name: String, auth_token: String) {
+pub async fn create_cache(cache_name: String, auth_token: String) -> Result<(), CliError> {
     info!("create cache called");
-    let mut momento = get_momento_instance(auth_token).await;
+    let mut momento = get_momento_instance(auth_token).await?;
     match momento.create_cache(&cache_name).await {
         Ok(_) => info!("created cache {}", cache_name),
-        Err(e) => panic!("{}", e),
-    }
+        Err(e) => return Err(CliError { msg: e.to_string() }),
+    };
+    Ok(())
 }
 
-pub async fn delete_cache(cache_name: String, auth_token: String) {
+pub async fn delete_cache(cache_name: String, auth_token: String) -> Result<(), CliError> {
     info!("delete cache called");
-    let mut momento = get_momento_instance(auth_token).await;
+    let mut momento = get_momento_instance(auth_token).await?;
     match momento.delete_cache(&cache_name).await {
         Ok(_) => info!("deleted cache {}", cache_name),
-        Err(e) => panic!("{}", e),
-    }
+        Err(e) => return Err(CliError { msg: e.to_string() }),
+    };
+    Ok(())
 }
 
-pub async fn list_caches(auth_token: String) {
+pub async fn list_caches(auth_token: String) -> Result<(), CliError> {
     info!("list cache called");
-    let mut momento = get_momento_instance(auth_token).await;
+    let mut momento = get_momento_instance(auth_token).await?;
     match momento.list_caches(None).await {
         Ok(res) => {
             res.caches
                 .into_iter()
                 .for_each(|cache| println!("{}", cache.cache_name));
         }
-        Err(e) => panic!("{}", e),
+        Err(e) => return Err(CliError { msg: e.to_string() }),
     }
+    Ok(())
 }
 
 pub async fn set(
@@ -55,18 +61,19 @@ pub async fn set(
     key: String,
     value: String,
     ttl_seconds: u32,
-) {
+) -> Result<(), CliError> {
     info!("setting key: {} into cache: {}", key, cache_name);
-    let cache = get_momento_cache(cache_name, auth_token).await;
+    let cache = get_momento_cache(cache_name, auth_token).await?;
     match cache.set(key, value, Some(ttl_seconds)).await {
         Ok(_) => info!("set success"),
-        Err(e) => panic!("{}", e),
-    }
+        Err(e) => return Err(CliError { msg: e.to_string() }),
+    };
+    Ok(())
 }
 
-pub async fn get(cache_name: String, auth_token: String, key: String) {
+pub async fn get(cache_name: String, auth_token: String, key: String) -> Result<(), CliError> {
     info!("getting key: {} from cache: {}", key, cache_name);
-    let cache = get_momento_cache(cache_name, auth_token).await;
+    let cache = get_momento_cache(cache_name, auth_token).await?;
 
     match cache.get(key).await {
         Ok(r) => {
@@ -79,6 +86,11 @@ pub async fn get(cache_name: String, auth_token: String, key: String) {
                 info!("cache miss");
             }
         }
-        Err(e) => panic!("failed to get from cache, error: {}", e),
+        Err(e) => {
+            return Err(CliError {
+                msg: format!("failed to get from cache: {}", e),
+            })
+        }
     };
+    Ok(())
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -1,0 +1,19 @@
+use std::fmt;
+
+use colored::Colorize;
+
+pub struct CliError {
+    pub(crate) msg: String,
+}
+
+impl fmt::Debug for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {:#?}", "ERROR".red().bold(), self.msg.red())
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", "ERROR".red().bold(), self.msg.red())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::panic;
+use std::{panic, process::exit};
 
 use clap::StructOpt;
 use env_logger::Env;
@@ -162,6 +162,8 @@ async fn main() {
     }));
 
     if let Err(e) = entrypoint().await {
-        eprintln!("{}", e)
+        eprintln!("{}", e);
+        exit(1)
     }
+    exit(0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,5 +165,4 @@ async fn main() {
         eprintln!("{}", e);
         exit(1)
     }
-    exit(0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ enum CacheCommand {
 }
 
 async fn entrypoint() -> Result<(), CliError> {
-    let args = Momento::from_args();
+    let args = Momento::parse();
 
     let log_level = if args.verbose { "debug" } else { "info" };
 
@@ -144,7 +144,7 @@ async fn entrypoint() -> Result<(), CliError> {
             }
         },
         Subcommand::Configure { profile } => {
-            commands::configure::configure::configure_momento(&profile).await
+            commands::configure::configure::configure_momento(&profile).await?
         }
         Subcommand::Account { operation } => match operation {
             AccountCommand::Signup { email, region } => {

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -2,62 +2,69 @@ use std::env;
 
 use crate::{
     config::{Config, Credentials, Profiles},
+    error::CliError,
     utils::file::{get_config_file_path, get_credentials_file_path, read_toml_file},
 };
 
-pub async fn get_creds_and_config() -> (Credentials, Config) {
+pub async fn get_creds_and_config() -> Result<(Credentials, Config), CliError> {
     let profile = get_profile_to_use();
     let creds = match get_creds_for_profile(&profile).await {
         Ok(c) => c,
-        Err(e) => panic!("{}", e),
+        Err(e) => return Err(e),
     };
     let config = match get_config_for_profile(&profile).await {
         Ok(c) => c,
-        Err(e) => panic!("{}", e),
+        Err(e) => return Err(e),
     };
 
-    return (creds, config);
+    return Ok((creds, config));
 }
 
 pub fn get_profile_to_use() -> String {
     env::var("MOMENTO_PROFILE").unwrap_or("default".to_string())
 }
 
-pub async fn get_creds_for_profile(profile: &str) -> Result<Credentials, String> {
+pub async fn get_creds_for_profile(profile: &str) -> Result<Credentials, CliError> {
     let path = get_credentials_file_path();
     let credentials_toml = match read_toml_file::<Profiles<Credentials>>(&path).await {
         Ok(c) => c,
         Err(_) => {
-            return Err(format!(
+            return Err(CliError {
+                msg: format!(
                 "failed to read credentials, please run 'momento configure' to setup credentials"
-            ))
+            ),
+            })
         }
     };
 
     let creds_result = match credentials_toml.profile.get(profile) {
         Some(c) => c,
-        None => return Err(format!("failed to get credentials for profile {}, please run 'momento configure' to confiure your profile", profile)),
+        None => return Err(CliError{
+            msg: format!("failed to get credentials for profile {}, please run 'momento configure' to confiure your profile", profile)
+        }),
     };
 
     return Ok(creds_result.clone());
 }
 
-pub async fn get_config_for_profile(profile: &str) -> Result<Config, String> {
+pub async fn get_config_for_profile(profile: &str) -> Result<Config, CliError> {
     let path = get_config_file_path();
     let profile_toml = match read_toml_file::<Profiles<Config>>(&path).await {
         Ok(c) => c,
-        Err(e) => return Err(
-            format!("failed to read profile '{}', please run 'momento configure' to setup your profile, {:#?}", profile, e)
-        ),
+        Err(e) => return Err(CliError{
+            msg: format!("failed to read profile '{}', please run 'momento configure' to setup your profile, {:#?}", profile, e)
+    }),
     };
 
     let config_result = match profile_toml.profile.get(profile) {
         Some(c) => c,
         None => {
-            return Err(format!(
+            return Err(CliError {
+                msg: format!(
             "failed to read profile {}, please run 'momento configure' to confiure your profile",
             profile
-        ))
+        ),
+            })
         }
     };
 


### PR DESCRIPTION
closes #42 
closes #41 
<img width="694" alt="Screen Shot 2022-02-01 at 4 25 15 PM" src="https://user-images.githubusercontent.com/11823378/152073665-3785f159-0c40-4915-8248-ac4122429ab6.png">

Right now, I just implemented 1 error type called `CliError`, but I figured that we could pretty easily add more custom error types down the line, and each can be formatted appropriately

