### PR TITLE
Update CLI to consume new Rust SDK changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ### Starting Off
 1. git submodule init
 1. git submodule sync
-1. git submodule update
+1. git submodule update --recursive --remote
 
 ### Building
 1. cargo build

--- a/src/commands/cache/cache.rs
+++ b/src/commands/cache/cache.rs
@@ -1,22 +1,11 @@
 use log::info;
-use momento::{cache::CacheClient, sdk::Momento};
+use momento::simple_cache_client::SimpleCacheClient;
 
 use crate::error::CliError;
 
-async fn get_momento_instance(auth_token: String) -> Result<Momento, CliError> {
-    match Momento::new(auth_token).await {
+async fn get_momento_instance(auth_token: String) -> Result<SimpleCacheClient, CliError> {
+    match SimpleCacheClient::new(auth_token, 100).await {
         Ok(m) => Ok(m),
-        Err(e) => Err(CliError { msg: e.to_string() }),
-    }
-}
-
-async fn get_momento_cache(
-    cache_name: String,
-    auth_token: String,
-) -> Result<CacheClient, CliError> {
-    let mut momento = get_momento_instance(auth_token).await?;
-    match momento.get_cache(&cache_name, 100).await {
-        Ok(c) => Ok(c),
         Err(e) => Err(CliError { msg: e.to_string() }),
     }
 }
@@ -63,8 +52,11 @@ pub async fn set(
     ttl_seconds: u32,
 ) -> Result<(), CliError> {
     info!("setting key: {} into cache: {}", key, cache_name);
-    let cache = get_momento_cache(cache_name, auth_token).await?;
-    match cache.set(key, value, Some(ttl_seconds)).await {
+    let mut momento = get_momento_instance(auth_token).await?;
+    match momento
+        .set(&cache_name, key, value, Some(ttl_seconds))
+        .await
+    {
         Ok(_) => info!("set success"),
         Err(e) => return Err(CliError { msg: e.to_string() }),
     };
@@ -73,9 +65,8 @@ pub async fn set(
 
 pub async fn get(cache_name: String, auth_token: String, key: String) -> Result<(), CliError> {
     info!("getting key: {} from cache: {}", key, cache_name);
-    let cache = get_momento_cache(cache_name, auth_token).await?;
-
-    match cache.get(key).await {
+    let mut momento = get_momento_instance(auth_token).await?;
+    match momento.get(&cache_name, key).await {
         Ok(r) => {
             if matches!(
                 r.result,


### PR DESCRIPTION
Follow-up to https://github.com/momentohq/client-sdk-rust/pull/13

- update CONTRIBUTING.md with command that ensures we pull the latest commits from submodules
- fix: update CLI to consume new Rust SDK changes

Only updates our CLI to consume new API changes for managing `SimpleCacheClient` objects.

Testing:
* `cargo build && cargo test`
* `cargo fmt`
* Run CLI against dev cell:

```
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹update-sdk-consumption› » ./target/debug/momento cache list
[2022-02-03T17:45:52Z INFO  momento::commands::cache::cache] list cache called
example-cache
cache
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹update-sdk-consumption› » ./target/debug/momento cache create --name fooBarBaz
[2022-02-03T17:46:01Z INFO  momento::commands::cache::cache] create cache called
[2022-02-03T17:46:02Z INFO  momento::commands::cache::cache] created cache fooBarBaz
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹update-sdk-consumption› » ./target/debug/momento cache delete --name fooBarBaz
[2022-02-03T17:46:06Z INFO  momento::commands::cache::cache] delete cache called
[2022-02-03T17:46:07Z INFO  momento::commands::cache::cache] deleted cache fooBarBaz
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹update-sdk-consumption› » ./target/debug/momento cache set --key foo --value bar --ttl 30 --name example-cache
[2022-02-03T17:46:13Z INFO  momento::commands::cache::cache] setting key: foo into cache: example-cache
[2022-02-03T17:46:14Z INFO  momento::commands::cache::cache] set success
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹update-sdk-consumption› » ./target/debug/momento cache get --key foo --name example-cache
[2022-02-03T17:46:18Z INFO  momento::commands::cache::cache] getting key: foo from cache: example-cache
bar
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹update-sdk-consumption› »
```
