### PR TITLE
chore: Add JP translation for README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,16 +1,22 @@
 ### 開始方法
 
-1. git submodule init
-1. git submodule sync
-1. git submodule update --recursive --remote
+```
+git submodule init
+git submodule sync
+git submodule update --recursive --remote
+```
 
 ## ビルド
 
-1. cargo build
+```
+cargo build
+```
 
 ## テスト
 
-1. cargo test
+```
+cargo test
+```
 
 ## デプロイ
 

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -1,0 +1,18 @@
+### 開始方法
+
+1. git submodule init
+1. git submodule sync
+1. git submodule update --recursive --remote
+
+## ビルド
+
+1. cargo build
+
+## テスト
+
+1. cargo test
+
+## デプロイ
+
+マージ後こちらのリポジトリにプルリクエストが作成されます。https://github.com/momentohq/homebrew-tap
+プルリクエストに対し全てのチェックが完了、合格した後、`pr-pull`というラベルで承認いたします。その後、homebrew ボットにより自動的にマージされ、リリースが作成されます。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,23 @@
 ### Starting Off
-1. git submodule init
-1. git submodule sync
-1. git submodule update --recursive --remote
+
+```
+git submodule init
+git submodule sync
+git submodule update --recursive --remote
+```
 
 ### Building
-1. cargo build
+
+```
+cargo build
+```
 
 ### Testing
-1. cargo test
+
+```
+cargo test
+```
 
 ### Deploying
+
 After merge a pr will be created in this repo https://github.com/momentohq/homebrew-tap. Once the pr passes all checks, approve the pr and label is as `pr-pull`. It will then get automatically merged by the homebrew bot, and a release will be created for it.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-_他言語バージョンの README もあります_: [English](README.md)
+_他言語バージョンもあります_: [English](README.md)
 
 <br>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,43 @@
+## 必要条件
+
+- MacOS もしくは Linux
+- [Homebrew](https://brew.sh/)
+
+## インストール方法
+
+```
+brew tap momentohq/tap
+brew install momento-cli
+```
+
+## サインアップ方法
+
+```
+momento account signup --region <ご希望のリージョン> --email <メールアドレス>
+```
+
+上記のコマンドはアクセストークンを発行し、提供していただいたメールアドレスに送付します。こちらのトークンは独自にキャッシュインタラクションを識別します。トークンはセンシティブなパスワードの様に扱ってください。また、秘密を確信するため全ての必要不可欠な対応をお願いします。AWS Secrets Manager の様なシークレット管理サービスにトークンを保管する事をお勧めします。
+
+## コンフィギュア
+
+```
+momento configure
+```
+
+上記コマンドは Momento オーストークンの入力を要求します。入力後はトークンは保存され、再利用されます。
+
+## CLI 使用方法
+
+```
+momento cache create --name example-cache
+momento cache set --key key --value value --ttl 100 --name example-cache
+momento cache get --key key --name example-cache
+```
+
+## ご自身のプロジェクト内での Momento 使用方法
+
+ご自身のプロジェクトに Momento をインテグレートする際には、ぜひ私達の[SDK](https://github.com/momentohq/client-sdk-examples)を確認してください！
+
+## Momento CLI リポジトリへの貢献について
+
+もし Momento CLI リポジトリへの貢献に興味がありましたら、こちらの[貢献ガイド](./CONTRIBUTING.ja.md)のご参考をお願いします。

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,3 +1,7 @@
+_他言語バージョンの README もあります_: [English](README.md)
+
+<br>
+
 ## 必要条件
 
 - MacOS もしくは Linux

--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
+Read this in other languages: [日本語](README.ja.md)
+
 ## Prerequisites
+
 - MacOS or Linux
 - [Homebrew](https://brew.sh/)
 
 ## Install
+
 ```
 brew tap momentohq/tap
 brew install momento-cli
 ```
+
 ## Sign up
+
 ```
 momento account signup --region <TYPE_DESIRED_REGION> --email <TYPE_YOUR_EMAIL_HERE>
 ```
+
 This generates an access token and sends it to the email provided. This token uniquely identifies cache interactions. The token should be treated like a sensitive password and all essential care must be taken to ensure its secrecy. We recommend that you store this token in a secret vault like AWS Secrets Manager.
 
 ## Configure
+
 ```
 momento configure
 ```
+
 This will prompt you for your Momento Auth Token, and save it to be reused.
 
 ## Use CLI
+
 ```
 momento cache create --name example-cache
 momento cache set --key key --value value --ttl 100 --name example-cache
@@ -27,7 +37,9 @@ momento cache get --key key --name example-cache
 ```
 
 ## Use Momento in Your Project
+
 Check out our [SDKs](https://github.com/momentohq/client-sdk-examples) to integrate Momento into your project!
 
 ## Contributing
+
 If you would like to contribute to the Momento Cli, please read out [Contributing Guide](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Momento CLI
 
 _Read this in other languages_: [日本語](README.ja.md)
+<br >
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-Read this in other languages: [日本語](README.ja.md)
+# Momento CLI
+
+_Read this in other languages_: [日本語](README.ja.md)
 
 ## Prerequisites
 


### PR DESCRIPTION
Added JP translation for both `README` and `CONTRIBUTING`

@danielamiao - It seems like the example has table of contents but since this README is short I'm not sure if it's needed. 
I skipped it for now.