### PR TITLE
feat: Add support for multiple profiles and only allow new credentials/config files creations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "configparser"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06821ea598337a8412cf47c5b71c3bc694a7f0aed188ac28b836fab164a2c202"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +673,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
+ "configparser",
  "env_logger",
  "home",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = {version = "1.0", features = ["derive"] }
 maplit = "1.0.2"
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false }
 momento = { path = "./client-sdk-rust" }
+configparser = "3.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,8 @@ enum CacheCommand {
     Create {
         #[structopt(name = "name", long, short)]
         cache_name: String,
+        #[structopt(name = "profile", long, short, default_value = "default")]
+        profile: String,
     },
 
     #[structopt(about = "Stores a given item in cache")]
@@ -74,6 +76,8 @@ enum CacheCommand {
             help = "Max time, in seconds, that the item will be stored in cache"
         )]
         ttl_seconds: Option<u32>,
+        #[structopt(name = "profile", long, short, default_value = "default")]
+        profile: String,
     },
 
     #[structopt(about = "Gets item from the cache")]
@@ -83,16 +87,23 @@ enum CacheCommand {
         // TODO: Add support for non-string key-value
         #[structopt(long, short)]
         key: String,
+        #[structopt(name = "profile", long, short, default_value = "default")]
+        profile: String,
     },
 
     #[structopt(about = "Deletes the cache")]
     Delete {
         #[structopt(name = "name", long, short)]
         cache_name: String,
+        #[structopt(name = "profile", long, short, default_value = "default")]
+        profile: String,
     },
 
     #[structopt(about = "Lists all momento caches")]
-    List {},
+    List {
+        #[structopt(name = "profile", long, short, default_value = "default")]
+        profile: String,
+    },
 }
 
 async fn entrypoint() -> Result<(), CliError> {
@@ -109,8 +120,11 @@ async fn entrypoint() -> Result<(), CliError> {
 
     match args.command {
         Subcommand::Cache { operation } => match operation {
-            CacheCommand::Create { cache_name } => {
-                let (creds, _config) = get_creds_and_config().await?;
+            CacheCommand::Create {
+                cache_name,
+                profile,
+            } => {
+                let (creds, _config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache::create_cache(cache_name, creds.token).await?
             }
             CacheCommand::Set {
@@ -118,8 +132,9 @@ async fn entrypoint() -> Result<(), CliError> {
                 key,
                 value,
                 ttl_seconds,
+                profile,
             } => {
-                let (creds, config) = get_creds_and_config().await?;
+                let (creds, config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache::set(
                     cache_name.unwrap_or(config.cache),
                     creds.token,
@@ -129,17 +144,24 @@ async fn entrypoint() -> Result<(), CliError> {
                 )
                 .await?
             }
-            CacheCommand::Get { cache_name, key } => {
-                let (creds, config) = get_creds_and_config().await?;
+            CacheCommand::Get {
+                cache_name,
+                key,
+                profile,
+            } => {
+                let (creds, config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache::get(cache_name.unwrap_or(config.cache), creds.token, key)
                     .await?;
             }
-            CacheCommand::Delete { cache_name } => {
-                let (creds, _config) = get_creds_and_config().await?;
+            CacheCommand::Delete {
+                cache_name,
+                profile,
+            } => {
+                let (creds, _config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache::delete_cache(cache_name, creds.token).await?
             }
-            CacheCommand::List {} => {
-                let (creds, _config) = get_creds_and_config().await?;
+            CacheCommand::List { profile } => {
+                let (creds, _config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache::list_caches(creds.token).await?
             }
         },

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -1,21 +1,21 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
+use configparser::ini::Ini;
 use home::home_dir;
 use log::debug;
-use serde::de;
 use tokio::fs::{self, File};
 
 use crate::error::CliError;
 
 pub fn get_credentials_file_path() -> String {
     let momento_home = get_momento_dir();
-    return format!("{}/credentials.toml", momento_home);
+    return format!("{}/credentials", momento_home);
 }
 
 pub fn get_config_file_path() -> String {
     let momento_home = get_momento_dir();
-    return format!("{}/config.toml", momento_home);
+    return format!("{}/config", momento_home);
 }
 
 pub fn get_momento_dir() -> String {
@@ -23,48 +23,38 @@ pub fn get_momento_dir() -> String {
     return format!("{}/.momento", home.clone().display());
 }
 
-pub async fn read_toml_file<T: de::DeserializeOwned>(path: &str) -> Result<T, CliError> {
-    let toml_str = match fs::read_to_string(&path).await {
-        Ok(s) => s,
+pub async fn read_file(path: &str) -> Result<Ini, CliError> {
+    let mut config = Ini::new_cs();
+    match config.load(path) {
+        Ok(_) => return Ok(config),
         Err(e) => {
             return Err(CliError {
                 msg: format!("failed to read file: {}", e),
             })
         }
-    };
-    match toml::from_str::<T>(&toml_str) {
-        Ok(c) => Ok(c),
-        Err(e) => Err(CliError {
-            msg: format!("failed to parse file: {}", e),
-        }),
     }
 }
 
-pub async fn write_to_existing_file(filepath: &str, buffer: &str) -> Result<(), CliError> {
-    match tokio::fs::write(filepath, buffer).await {
-        Ok(_) => debug!("wrote buffer to file {}", filepath),
-        Err(e) => {
-            return Err(CliError {
-                msg: format!("failed to write to file {}, error: {}", filepath, e),
-            })
-        }
-    };
-    Ok(())
-}
-
-pub async fn create_file_if_not_exists(path: &str) -> Result<(), CliError> {
+pub async fn create_file_if_not_exists(path: &str, file_name: &str) -> Result<(), CliError> {
     if !Path::new(path).exists() {
         let res = File::create(path).await;
         match res {
-            Ok(_) => debug!("created file {}", path),
+            Ok(_) => {
+                debug!("created file {}", path);
+                return Ok(());
+            }
             Err(e) => {
                 return Err(CliError {
                     msg: format!("failed to create file {}, error: {}", path, e),
                 })
             }
         }
-    };
-    Ok(())
+    } else {
+        // Throw error if credentials or config files already exists
+        return Err(CliError {
+            msg: format!("Existing {} file detected, please edit $HOME/.momento/{} directly to add or modify profiles", file_name, file_name),
+        });
+    }
 }
 
 pub async fn set_file_readonly(path: &str) -> Result<(), CliError> {

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -1,13 +1,12 @@
 use std::env;
 
 use crate::{
-    config::{Config, Credentials, Profiles},
+    config::{Config, Credentials},
     error::CliError,
-    utils::file::{get_config_file_path, get_credentials_file_path, read_toml_file},
+    utils::file::{get_config_file_path, get_credentials_file_path, read_file},
 };
 
-pub async fn get_creds_and_config() -> Result<(Credentials, Config), CliError> {
-    let profile = get_profile_to_use();
+pub async fn get_creds_and_config(profile: &str) -> Result<(Credentials, Config), CliError> {
     let creds = match get_creds_for_profile(&profile).await {
         Ok(c) => c,
         Err(e) => return Err(e),
@@ -20,13 +19,9 @@ pub async fn get_creds_and_config() -> Result<(Credentials, Config), CliError> {
     return Ok((creds, config));
 }
 
-pub fn get_profile_to_use() -> String {
-    env::var("MOMENTO_PROFILE").unwrap_or("default".to_string())
-}
-
 pub async fn get_creds_for_profile(profile: &str) -> Result<Credentials, CliError> {
     let path = get_credentials_file_path();
-    let credentials_toml = match read_toml_file::<Profiles<Credentials>>(&path).await {
+    let credentials = match read_file(&path).await {
         Ok(c) => c,
         Err(_) => {
             return Err(CliError {
@@ -37,36 +32,47 @@ pub async fn get_creds_for_profile(profile: &str) -> Result<Credentials, CliErro
         }
     };
 
-    let creds_result = match credentials_toml.profile.get(profile) {
+    let creds_result = match credentials.get(profile, "token") {
         Some(c) => c,
         None => return Err(CliError{
-            msg: format!("failed to get credentials for profile {}, please run 'momento configure' to confiure your profile", profile)
+            msg: format!("failed to get credentials for profile {}, please run 'momento configure' to configure your profile", profile)
         }),
     };
 
-    return Ok(creds_result.clone());
+    return Ok(Credentials {
+        token: creds_result,
+    });
 }
 
 pub async fn get_config_for_profile(profile: &str) -> Result<Config, CliError> {
     let path = get_config_file_path();
-    let profile_toml = match read_toml_file::<Profiles<Config>>(&path).await {
+    let configs = match read_file(&path).await {
         Ok(c) => c,
-        Err(e) => return Err(CliError{
-            msg: format!("failed to read profile '{}', please run 'momento configure' to setup your profile, {:#?}", profile, e)
-    }),
-    };
-
-    let config_result = match profile_toml.profile.get(profile) {
-        Some(c) => c,
-        None => {
+        Err(_) => {
             return Err(CliError {
                 msg: format!(
-            "failed to read profile {}, please run 'momento configure' to confiure your profile",
-            profile
-        ),
+                "failed to read credentials, please run 'momento configure' to setup credentials"
+            ),
             })
         }
     };
 
-    return Ok(config_result.clone());
+    let cache_result = match configs.get(profile, "cache") {
+        Some(c) => c,
+        None => return Err(CliError{
+            msg: format!("failed to get cache config for profile {}, please run 'momento configure' to configure your profile", profile)
+        }),
+    };
+
+    let ttl_result = match configs.get(profile, "ttl") {
+        Some(c) => c,
+        None => return Err(CliError{
+            msg: format!("failed to get ttl config for profile {}, please run 'momento configure' to configure your profile", profile)
+        }),
+    };
+
+    return Ok(Config {
+        cache: cache_result,
+        ttl: ttl_result.parse::<u32>().unwrap(),
+    });
 }


### PR DESCRIPTION
Conducted local test scenarios:
- Run `momento cache list --profile <profile>` to check if we can specify a profile. When `--profile` is not specified, `default` profile will be used.
<img width="792" alt="image" src="https://user-images.githubusercontent.com/22686260/157311775-2e1e7490-75b2-4eeb-9c88-10f7c7152408.png">
<br>

- Run `momento configure` without credentials or config files -> create new credentials and config files with `[default]` section in INI format.
<br>

- Run `momento configure` only with existing credentials file -> create a new config file with [default]` section in INI format and throw an error saying that the credentials file already exists.
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/22686260/157311231-9d6e0f67-dfd6-4916-b95f-cc54ecb6391d.png">
<br>

- Run `momento configure` only with existing config file -> create a new credentials file with [default]` section in INI format and throw an error saying that the config file already exists.
<img width="972" alt="image" src="https://user-images.githubusercontent.com/22686260/157311287-d8c6a9c5-ccd6-46b7-9ed4-2daef81188b4.png">
<br>

- Run `momento configure` with both existing credentials and config files, throw an error saying that both credentials and config files exist.
<img width="842" alt="image" src="https://user-images.githubusercontent.com/22686260/157311321-94c96baa-66be-436d-8210-b63deb4f2e79.png">

Closes #56 
Closes #57 