### PR TITLE
chore: update cli with latest sdk changes, use uint64 for ttl

### DIFF
--- a/src/commands/cache/cache_cli.rs
+++ b/src/commands/cache/cache_cli.rs
@@ -49,7 +49,7 @@ pub async fn set(
     auth_token: String,
     key: String,
     value: String,
-    ttl_seconds: u32,
+    ttl_seconds: u64,
 ) -> Result<(), CliError> {
     debug!("setting key: {} into cache: {}", key, cache_name);
     let mut momento = get_momento_instance(auth_token).await?;

--- a/src/commands/configure/configure_cli.rs
+++ b/src/commands/configure/configure_cli.rs
@@ -112,7 +112,7 @@ async fn prompt_user_for_config(profile_name: &str) -> Result<Config, CliError> 
         false,
     )
     .await?
-    .parse::<u32>()
+    .parse::<u64>()
     {
         Ok(ttl) => ttl,
         Err(e) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ pub enum FileTypes {
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct Config {
     pub cache: String,
-    pub ttl: u32,
+    pub ttl: u64,
 }
 
 #[derive(Deserialize, Serialize, Clone, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ enum CacheCommand {
             short = 't',
             help = "Max time, in seconds, that the item will be stored in cache"
         )]
-        ttl_seconds: Option<u32>,
+        ttl_seconds: Option<u64>,
         #[structopt(long, short, default_value = "default")]
         profile: String,
     },

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -65,6 +65,6 @@ pub async fn get_config_for_profile(profile: &str) -> Result<Config, CliError> {
 
     Ok(Config {
         cache: cache_result,
-        ttl: ttl_result.parse::<u32>().unwrap(),
+        ttl: ttl_result.parse::<u64>().unwrap(),
     })
 }


### PR DESCRIPTION
* Updates CLI with latest Momento Rust SDK
* Updates CLI to use `uint64` when handling `ttl_seconds`
