### PR TITLE
chore: Add `--quick` flag to use default cache name and TTL on `momento configure`

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,8 +12,8 @@ brew install momento-cli
 # サインアップ [available regions are us-west-2, us-east-1, ap-northeast-1, default is us-west-2]
 momento account signup --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
-# 上記のメールアドレスに送付されたトークンであなたのアカウントコンフィグ
-momento configure
+# 上記のメールアドレスに送付されたトークンとデフォルトのキャッシュ名とTTLであなたのアカウントコンフィグ
+momento configure --quick
 
 # キャッシュ作成
 momento cache create --name example-cache

--- a/README.md
+++ b/README.md
@@ -2,22 +2,18 @@
 
 Japanese: [日本語](README.ja.md)
 
-
-
-
-
-
 ## Quick Start
+
 ```
-# Install 
+# Install
 brew tap momentohq/tap
 brew install momento-cli
 
 # Sign Up [available regions are us-west-2, us-east-1, ap-northeast-1, default is us-west-2]
 momento account signup --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
-# Configure your account with the credentials in your email
-momento configure
+# Configure your account with the credentials in your email and default cache name and TTL
+momento configure --quick
 
 # Make a cache
 momento cache create --name example-cache
@@ -29,13 +25,13 @@ momento cache get --key key --name example-cache
 ```
 
 ## Upgrading
+
 ```
 brew update momento-cli
 brew upgrade momento-cli
 ```
 
-## Sign up 
-
+## Sign up
 
 **NOTE:** If you run into errors during signup, please ensure you have upgraded to the [latest version](https://github.com/momentohq/momento-cli/releases/latest) of our CLI.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ brew install momento-cli
 # Sign Up [available regions are us-west-2, us-east-1, ap-northeast-1, default is us-west-2]
 momento account signup --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
-# Configure your account with the credentials in your email and default cache name and TTL
+# Configure your account with the credentials in your email, plus default cache name and TTL
 momento configure --quick
 
 # Make a cache

--- a/src/commands/configure/configure_cli.rs
+++ b/src/commands/configure/configure_cli.rs
@@ -1,6 +1,8 @@
+use log::debug;
 use log::info;
 use std::path::Path;
 use tokio::fs;
+use tokio::io::{self, AsyncWriteExt};
 
 use crate::{
     commands::cache::cache_cli::create_cache,
@@ -91,6 +93,19 @@ async fn prompt_user_for_config(profile_name: &str) -> Result<Config, CliError> 
         "default-cache"
     } else {
         current_config.cache.as_str()
+    };
+
+    let mut stdout = io::stdout();
+    let configure_desc = String::from(
+        "\nPress Enter/Return to use default cache name and ttl which are displayed in []\n",
+    );
+    match stdout.write(configure_desc.as_bytes()).await {
+        Ok(_) => debug!("wrote prompt '{}' to stdout", configure_desc),
+        Err(e) => {
+            return Err(CliError {
+                msg: format!("failed to write prompt to stdout: {}", e),
+            })
+        }
     };
     let cache_name = match prompt_user_for_input("Default Cache", prompt_cache, false).await {
         Ok(s) => s,

--- a/src/commands/configure/configure_cli.rs
+++ b/src/commands/configure/configure_cli.rs
@@ -59,14 +59,15 @@ pub async fn configure_momento(quick: bool, profile_name: &str) -> Result<(), Cl
             return Err(e);
         }
     }
-    match create_cache(config.cache, credentials.token).await {
+    match create_cache(config.cache.clone(), credentials.token).await {
         Ok(_) => info!(
-            "default-cache successfully created with default TTL of {}s",
+            "{} successfully created as the default with default TTL of {}s",
+            config.cache.clone(),
             config.ttl
         ),
         Err(e) => {
             if e.msg.contains("already exists") {
-                info!("default-cache already exists");
+                info!("{} as the default already exists", config.cache);
             } else {
                 return Err(e);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ enum Subcommand {
     },
     #[structopt(about = "Configure credentials")]
     Configure {
+        #[structopt(long, short)]
+        quick: bool,
         #[structopt(long, short, default_value = "default")]
         profile: String,
     },
@@ -198,8 +200,8 @@ async fn entrypoint() -> Result<(), CliError> {
                 commands::cache::cache_cli::list_caches(creds.token).await?
             }
         },
-        Subcommand::Configure { profile } => {
-            commands::configure::configure_cli::configure_momento(&profile).await?
+        Subcommand::Configure { quick, profile } => {
+            commands::configure::configure_cli::configure_momento(quick, &profile).await?
         }
         Subcommand::Account { operation } => match operation {
             AccountCommand::Signup { email, region } => {


### PR DESCRIPTION
Added `--quick` flag to use the default cache name and TTL without users entering anything.
Users are still required to enter their auth token.

First time creating `default-cache`
```
./target/debug/momento configure --quick
Token [****]: gregger
[2022-04-13T18:28:40Z INFO  momento::commands::configure::configure_cli] default-cache successfully created with default TTL of 600s
```

`default-cache` already exists
```
./target/debug/momento configure --quick
Token [****]: gdfgfdg
[2022-04-13T18:29:14Z INFO  momento::commands::configure::configure_cli] default-cache already exists
```

Closes #109 