### PR TITLE
chore: Improve cache miss handling

### DIFF
--- a/src/commands/cache/cache_cli.rs
+++ b/src/commands/cache/cache_cli.rs
@@ -1,6 +1,7 @@
 use log::{debug, info};
 use momento::simple_cache_client::SimpleCacheClient;
 use std::num::NonZeroU64;
+use std::process::exit;
 
 use crate::error::CliError;
 
@@ -81,6 +82,7 @@ pub async fn get(cache_name: String, auth_token: String, key: String) -> Result<
                 println!("{}", r.as_string());
             } else {
                 info!("cache miss");
+                exit(1);
             }
         }
         Err(e) => {

--- a/src/commands/cache/cache_cli.rs
+++ b/src/commands/cache/cache_cli.rs
@@ -70,7 +70,12 @@ pub async fn set(
     Ok(())
 }
 
-pub async fn get(cache_name: String, auth_token: String, key: String) -> Result<(), CliError> {
+pub async fn get(
+    cache_name: String,
+    auth_token: String,
+    key: String,
+    quiet: bool,
+) -> Result<(), CliError> {
     debug!("getting key: {} from cache: {}", key, cache_name);
     let mut momento = get_momento_instance(auth_token).await?;
     match momento.get(&cache_name, key).await {
@@ -81,7 +86,9 @@ pub async fn get(cache_name: String, auth_token: String, key: String) -> Result<
             ) {
                 println!("{}", r.as_string());
             } else {
-                info!("cache miss");
+                if !quiet {
+                    info!("cache miss");
+                }
                 exit(1);
             }
         }

--- a/src/commands/cache/cache_cli.rs
+++ b/src/commands/cache/cache_cli.rs
@@ -1,4 +1,4 @@
-use log::{debug, info};
+use log::debug;
 use momento::simple_cache_client::SimpleCacheClient;
 use std::num::NonZeroU64;
 use std::process::exit;
@@ -70,12 +70,7 @@ pub async fn set(
     Ok(())
 }
 
-pub async fn get(
-    cache_name: String,
-    auth_token: String,
-    key: String,
-    quiet: bool,
-) -> Result<(), CliError> {
+pub async fn get(cache_name: String, auth_token: String, key: String) -> Result<(), CliError> {
     debug!("getting key: {} from cache: {}", key, cache_name);
     let mut momento = get_momento_instance(auth_token).await?;
     match momento.get(&cache_name, key).await {
@@ -86,9 +81,7 @@ pub async fn get(
             ) {
                 println!("{}", r.as_string());
             } else {
-                if !quiet {
-                    info!("cache miss");
-                }
+                debug!("cache miss");
                 exit(1);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,8 @@ enum CacheCommand {
         key: String,
         #[structopt(long, short, default_value = "default")]
         profile: String,
+        #[structopt(long, short)]
+        quiet: bool,
     },
 
     #[structopt(about = "Delete the cache")]
@@ -178,12 +180,14 @@ async fn entrypoint() -> Result<(), CliError> {
                 cache_name,
                 key,
                 profile,
+                quiet,
             } => {
                 let (creds, config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache_cli::get(
                     cache_name.unwrap_or(config.cache),
                     creds.token,
                     key,
+                    quiet,
                 )
                 .await?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,8 +118,6 @@ enum CacheCommand {
         key: String,
         #[structopt(long, short, default_value = "default")]
         profile: String,
-        #[structopt(long, short)]
-        quiet: bool,
     },
 
     #[structopt(about = "Delete the cache")]
@@ -180,14 +178,12 @@ async fn entrypoint() -> Result<(), CliError> {
                 cache_name,
                 key,
                 profile,
-                quiet,
             } => {
                 let (creds, config) = get_creds_and_config(&profile).await?;
                 commands::cache::cache_cli::get(
                     cache_name.unwrap_or(config.cache),
                     creds.token,
                     key,
-                    quiet,
                 )
                 .await?;
             }


### PR DESCRIPTION
- Exit with code 1 on cache miss
```
./target/debug/momento cache get --key erika
echo $?                                     
1
```

- Add `--quiet` flag on the set command so that `[2022-04-13T20:55:58Z INFO  momento::commands::cache::cache_cli] cache miss` won't be displayed


Closes #108 