### PR TITLE
chore: Add `publish-linux-assets` job to cd workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,6 +97,36 @@ jobs:
         id: release
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
 
+  publish-linux-assets:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux2014_x86_64
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: Build tar.gz and publish asset
+        run: |
+          VERSION=${{ needs.release.outputs.version }}
+          BINARY_FILE=momento-cli-$VERSION.x86_64_linux.tar.gz
+          BINARY_DIR=momento-cli
+          mkdir $BINARY_DIR 
+          cargo build --release
+          mv ./target/release/momento $BINARY_DIR
+          tar zcvf $BINARY_FILE $BINARY_DIR
+          AUTH="Authorization: token ${{ secrets.PRIVATE_REPO_RELEASE_ACCESS }}"
+          LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
+          RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)
+          GH_ASSET="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${BINARY_FILE}"
+          echo $GH_ASSET
+          curl --data-binary @$BINARY_FILE -H "$AUTH" -H "Content-Type: application/octet-stream" $GH_ASSET
+        shell: bash
+
   update-cargo:
     runs-on: ubuntu-latest
     needs: release


### PR DESCRIPTION
@eaddingtonwhite figured out that we can build binary for Linux can be used on Ubuntu, CentOS, and Amazon Linux AMIs by building binary in a Docker container with [quay.io/pypa/manylinux2014_x86_64](http://quay.io/pypa/manylinux2014_x86_64) image.
Utilizing the `container`(https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer)  workflow syntax, build momento cli binary, tar.gz, and upload it as a GH asset.

Closes #97 