### PR TITLE
chore: Update `README` and CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           yum install jq -y
           VERSION=${{ needs.release.outputs.version }}
-          BINARY_FILE=momento-cli-$VERSION.x86_64_linux.tar.gz
+          BINARY_FILE=momento-cli-$VERSION_linux_x86_64.tar.gz
           cargo build --release
           tar zcvf $BINARY_FILE ./target/release/momento
           AUTH="Authorization: token ${{ secrets.PRIVATE_REPO_RELEASE_ACCESS }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -115,11 +115,8 @@ jobs:
           yum install jq -y
           VERSION=${{ needs.release.outputs.version }}
           BINARY_FILE=momento-cli-$VERSION.x86_64_linux.tar.gz
-          BINARY_DIR=momento-cli
-          mkdir $BINARY_DIR 
           cargo build --release
-          mv ./target/release/momento $BINARY_DIR
-          tar zcvf $BINARY_FILE $BINARY_DIR
+          tar zcvf $BINARY_FILE ./target/release/momento
           AUTH="Authorization: token ${{ secrets.PRIVATE_REPO_RELEASE_ACCESS }}"
           LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
           RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,8 @@ _他言語バージョンもあります_: [English](README.md)
 
 ## クイックスタート
 
+Linux のインストールマニュアルは[こちら](https://github.com/momentohq/momento-cli#linux)を参照してください。
+
 ```
 # インストール
 brew tap momentohq/tap
@@ -23,6 +25,14 @@ momento cache set --key key --value value --ttl 100 --name example-cache
 momento cache get --key key --name example-cache
 
 ```
+
+## インストール
+
+### Linux
+
+1. 最新の linux tar.gz ファイルを[https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)よりダウンロードする。
+2. `tar -xvf momento-cli-X.X.X.x86_64_linux.tar.gz`ファイルを展開する。
+3. `./momento`を実行パスに置く。
 
 ## アップグレード
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -31,7 +31,7 @@ momento cache get --key key --name example-cache
 ### Linux
 
 1. 最新の linux tar.gz ファイルを[https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)よりダウンロードする。
-2. `tar -xvf momento-cli-X.X.X.x86_64_linux.tar.gz`ファイルを展開する。
+2. `tar -xvf momento-cli-X.X.X_linux_x86_64.tar.gz`ファイルを展開する。
 3. `./momento`を実行パスに置く。
 
 ## アップグレード

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Japanese: [日本語](README.ja.md)
 
 ## Quick Start
 
+Please refer to the installation instructions for Linux [here](https://github.com/momentohq/momento-cli#linux).
+
 ```
 # Install
 brew tap momentohq/tap
@@ -23,6 +25,14 @@ momento cache set --key key --value value --ttl 100 --name example-cache
 momento cache get --key key --name example-cache
 
 ```
+
+## Installation
+
+### Linux
+
+1. Download the latest linux tar.gz file from [https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)
+2. Unzip the file: `tar -xvf momento-cli-X.X.X.x86_64_linux.tar.gz`
+3. Move `./momento` to your execution path.
 
 ## Upgrading
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ momento cache get --key key --name example-cache
 ### Linux
 
 1. Download the latest linux tar.gz file from [https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)
-2. Unzip the file: `tar -xvf momento-cli-X.X.X.x86_64_linux.tar.gz`
+2. Unzip the file: `tar -xvf momento-cli-X.X.X_linux_x86_64.tar.gz`
 3. Move `./momento` to your execution path.
 
 ## Upgrading


### PR DESCRIPTION
- Updated the CD workflow to only compress the momento binary file
- Updated both English and Japanese README to include installation instructions for Linux (referenced the Stripe doc: https://stripe.com/docs/stripe-cli#install)