### PR TITLE
chore: comment out windows_i686 build step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -168,50 +168,45 @@ jobs:
           asset_name: ${{ steps.create_release.outputs.asset_name }}
           asset_content_type: application/zip
 
-      - name: Add mingw32 to path
-        shell: bash
-        run: |
-          echo "C:\msys64\mingw32\bin" >> $GITHUB_PATH
+      # Commenting out building i686 since the machine doesn't seem to have i686-w64-mingw32-gcc.exe compiler installed by default.
+      # Come back and work on this when customers ask 32-bit build.
+      #
+      # - name: Add mingw32 to path
+      #   shell: bash
+      #   run: |
+      #     echo "C:\msys64\mingw32\bin" >> $GITHUB_PATH
 
-      - run: |
-          Get-ChildItem -Path C:\msys64
-        shell: pwsh
+      # - name: Build zip for windows_i686 and create release
+      #   id: create_release_32
+      #   run: |
+      #     $env:Version = "${{ needs.release.outputs.version }}"
+      #     $env:BinaryFile32 = "momento-cli-" + $env:VERSION + ".windows_i686.zip"
+      #     rustup target add i686-pc-windows-gnu
+      #     cargo build --release --target i686-pc-windows-gnu
+      #     $env:CurrentDir = Get-Location
+      #     $env:LiteralPath = $env:CurrentDir + "\target\i686-pc-windows-gnu\release\momento.exe"
+      #     $env:DestinationPath = $env:CurrentDir + "\" + $env:BinaryFile32
+      #     Compress-Archive -LiteralPath $env:LiteralPath -DestinationPath $env:DestinationPath
+      #     $env:LatestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v" + $env:Version
+      #     $env:LatestReleaseUri
+      #     $env:LatestRelease = (Invoke-WebRequest -Uri $env:LatestReleaseUri -Method Get | Select-Object -Property Content).Content
+      #     $env:ReleaseId = $env:LatestRelease | jq -r .id
+      #     $GhAsset32 = "https://uploads.github.com/repos/momentohq/momento-cli/releases/" + $env:ReleaseId + "/assets?name=" + $env:BinaryFile32
+      #     $GhAsset32
+      #     echo "::set-output name=upload_url::$GhAsset32"
+      #     echo "::set-output name=asset_path::$env:DestinationPath"
+      #     echo "::set-output name=asset_name::$env:BinaryFile32"
+      #   shell: pwsh
 
-      - run: |
-          Get-ChildItem -Path C:\msys64\mingw32
-        shell: pwsh
-
-      - name: Build zip for windows_i686 and create release
-        id: create_release_32
-        run: |
-          $env:Version = "${{ needs.release.outputs.version }}"
-          $env:BinaryFile32 = "momento-cli-" + $env:VERSION + ".windows_i686.zip"
-          rustup target add i686-pc-windows-gnu
-          cargo build --release --target i686-pc-windows-gnu
-          $env:CurrentDir = Get-Location
-          $env:LiteralPath = $env:CurrentDir + "\target\i686-pc-windows-gnu\release\momento.exe"
-          $env:DestinationPath = $env:CurrentDir + "\" + $env:BinaryFile32
-          Compress-Archive -LiteralPath $env:LiteralPath -DestinationPath $env:DestinationPath
-          $env:LatestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v" + $env:Version
-          $env:LatestReleaseUri
-          $env:LatestRelease = (Invoke-WebRequest -Uri $env:LatestReleaseUri -Method Get | Select-Object -Property Content).Content
-          $env:ReleaseId = $env:LatestRelease | jq -r .id
-          $GhAsset32 = "https://uploads.github.com/repos/momentohq/momento-cli/releases/" + $env:ReleaseId + "/assets?name=" + $env:BinaryFile32
-          $GhAsset32
-          echo "::set-output name=upload_url::$GhAsset32"
-          echo "::set-output name=asset_path::$env:DestinationPath"
-          echo "::set-output name=asset_name::$env:BinaryFile32"
-        shell: pwsh
-
-      - name: Upload windows_i686 zip
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release_32.outputs.upload_url }}
-          asset_path: ${{ steps.create_release_32.outputs.asset_path }}
-          asset_name: ${{ steps.create_release_32.outputs.asset_name }}
-          asset_content_type: application/zip
+      # - name: Upload windows_i686 zip
+      #   uses: actions/upload-release-asset@v1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release_32.outputs.upload_url }}
+      #     asset_path: ${{ steps.create_release_32.outputs.asset_path }}
+      #     asset_name: ${{ steps.create_release_32.outputs.asset_name }}
+      #     asset_content_type: application/zip
 
   update-cargo:
     runs-on: ubuntu-latest

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@ _他言語バージョンもあります_: [English](README.md)
 
 ## クイックスタート
 
-Linux のインストールマニュアルは[こちら](https://github.com/momentohq/momento-cli/blob/main/README.ja.md#linux)を参照してください。
+Linux のインストールマニュアルは[こちら](https://github.com/momentohq/momento-cli/blob/main/README.ja.md#linux)、Windows のインストールマニュアルは[こちら](https://github.com/momentohq/momento-cli/blob/main/README.ja.md#windows)を参照してください。
 
 ```
 # インストール
@@ -30,9 +30,15 @@ momento cache get --key key --name example-cache
 
 ### Linux
 
-1. 最新の linux tar.gz ファイルを[https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)よりダウンロードする。
+1. 最新の linux tar.gz ファイルを[https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)からダウンロードする。
 2. `tar -xvf momento-cli-X.X.X.linux_x86_64.tar.gz`ファイルを展開する。
 3. `./momento`を実行パスに置く。
+
+### Windows
+
+1. 最新の windows zip ファイルを[https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)からダウンロードする。
+2. `momento-cli-X.X.X.windows_x86_64.zip`ファイルを展開する。
+3. 展開した.exe file を実行する。
 
 ## アップグレード
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Japanese: [日本語](README.ja.md)
 
 ## Quick Start
 
-Please refer to the installation instructions for Linux [here](https://github.com/momentohq/momento-cli/blob/main/README.md#linux).
+Please refer to the installation instructions for Linux [here](https://github.com/momentohq/momento-cli/blob/main/README.md#linux) and Windows [here](https://github.com/momentohq/momento-cli/blob/main/README.md#windows).
 
 ```
 # Install
@@ -33,6 +33,12 @@ momento cache get --key key --name example-cache
 1. Download the latest linux tar.gz file from [https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)
 2. Unzip the file: `tar -xvf momento-cli-X.X.X.linux_x86_64.tar.gz`
 3. Move `./momento` to your execution path.
+
+### Windows
+
+1. Download the latest windows zip file from [https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)
+2. Unzip the `momento-cli-X.X.X.windows_x86_64.zip` file
+3. Run the unzipped .exe file
 
 ## Upgrading
 


### PR DESCRIPTION
We successfully uploaded Windows 64-bit binary to GH Asset.
Spent some time to do the same for 32-bit binary; however it's not a priority to build 32-bit right now so we decided to postpone until customers ask for it.
Therefore, commenting out the building i686 step. 

Closes #122 