### PR TITLE
feat: Allow signups for Momento on GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ brew install momento-cli
 
 # Sign Up
 
-## AWS [available regions are us-west-2, us-east-1, ap-northeast-1, default is us-west-2]
+## AWS [available regions are us-west-2, us-east-1, ap-northeast-1]
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
-## GCP [available regions are us-east1, ap-northeast1, default is us-east1]
+## GCP [available regions are us-east1, ap-northeast1]
 momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
 
@@ -59,10 +59,7 @@ brew upgrade momento-cli
 
 ### Momento on AWS
 ```
-# default region is us-west-2
-momento account signup aws --email <TYPE_YOUR_EMAIL_HERE>
-
-# (optional) view help to see all available regions, and sign up for a specific region
+# View help to see all available regions, and sign up for a specific region
 momento account signup aws --help
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
@@ -72,10 +69,7 @@ momento configure
 
 ### Momento on GCP
 ```
-# default region is us-east1
-momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE>
-
-# (optional) view help to see all available regions, and sign up for a specific region
+# View help to see all available regions, and sign up for a specific region
 momento account signup gcp --help
 momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ Please refer to the installation instructions for Linux [here](https://github.co
 brew tap momentohq/tap
 brew install momento-cli
 
-# Sign Up [available regions are us-west-2, us-east-1, ap-northeast-1, default is us-west-2]
-momento account signup --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
+# Sign Up
+
+## AWS [available regions are us-west-2, us-east-1, ap-northeast-1, default is us-west-2]
+momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
+
+## GCP [available regions are us-east1, ap-northeast1, default is us-east1]
+momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
+
 
 # Configure your account with the credentials in your email, plus default cache name and TTL
 momento configure --quick
@@ -51,17 +57,30 @@ brew upgrade momento-cli
 
 **NOTE:** If you run into errors during signup, please ensure you have upgraded to the [latest version](https://github.com/momentohq/momento-cli/releases/latest) of our CLI.
 
+### Momento on AWS
 ```
 # default region is us-west-2
-momento account signup --email <TYPE_YOUR_EMAIL_HERE>
+momento account signup aws --email <TYPE_YOUR_EMAIL_HERE>
 
 # (optional) view help to see all available regions, and sign up for a specific region
-momento account signup --help
-momento account signup --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
+momento account signup aws --help
+momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
 # Configure CLI
 momento configure
+```
 
+### Momento on GCP
+```
+# default region is us-east1
+momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE>
+
+# (optional) view help to see all available regions, and sign up for a specific region
+momento account signup gcp --help
+momento account signup gcp --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
+
+# Configure CLI
+momento configure
 ```
 
 Upon signing up, Momento sends a token to the email provided. This token uniquely identifies cache interactions. The token should be treated like a sensitive password and all essential care must be taken to ensure its secrecy. We recommend that you store this token in a secret vault like AWS Secrets Manager.

--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -35,7 +35,11 @@ pub async fn signup_user(email: String, cloud: String, region: String) -> Result
     let endpoint = get_signup_endpoint();
     let url = format!("{}/token/create", endpoint);
 
-    let body = &CreateTokenBody { email, cloud, region };
+    let body = &CreateTokenBody {
+        email,
+        cloud,
+        region,
+    };
     info!("Signing up for Momento...");
     match Client::new().post(url).json(body).send().await {
         Ok(resp) => {

--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -15,6 +15,7 @@ struct CreateTokenResponse {
 #[derive(Serialize, Deserialize, Debug)]
 struct CreateTokenBody {
     email: String,
+    cloud: String,
     region: String,
 }
 
@@ -30,11 +31,11 @@ fn get_signup_endpoint() -> String {
     env::var("MOMENTO_SIGNUP_ENDPOINT").unwrap_or_else(|_| String::from(SIGNUP_ENDPOINT))
 }
 
-pub async fn signup_user(email: String, region: String) -> Result<(), CliError> {
+pub async fn signup_user(email: String, cloud: String, region: String) -> Result<(), CliError> {
     let endpoint = get_signup_endpoint();
     let url = format!("{}/token/create", endpoint);
 
-    let body = &CreateTokenBody { email, region };
+    let body = &CreateTokenBody { email, cloud, region };
     info!("Signing up for Momento...");
     match Client::new().post(url).json(body).send().await {
         Ok(resp) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,24 +79,14 @@ enum CloudSignupCommand {
     Gcp {
         #[structopt(long, short)]
         email: String,
-        #[structopt(
-            long,
-            short,
-            default_value = "us-east1",
-            help = "e.g. us-east1, ap-northeast1"
-        )]
+        #[structopt(long, short, help = "e.g. us-east1, ap-northeast1")]
         region: String,
     },
     #[structopt(about = "Signup for Momento on AWS")]
     Aws {
         #[structopt(long, short)]
         email: String,
-        #[structopt(
-            long,
-            short,
-            default_value = "us-west-2",
-            help = "e.g. us-west-2, us-east-1, ap-northeast-1"
-        )]
+        #[structopt(long, short, help = "e.g. us-west-2, us-east-1, ap-northeast-1")]
         region: String,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,16 +75,15 @@ enum AccountCommand {
 
 #[derive(Debug, StructOpt)]
 enum CloudSignupCommand {
-
     #[structopt(about = "Signup for Momento on GCP")]
     Gcp {
         #[structopt(long, short)]
         email: String,
         #[structopt(
-        long,
-        short,
-        default_value = "us-east1",
-        help = "e.g. us-east1, ap-northeast1"
+            long,
+            short,
+            default_value = "us-east1",
+            help = "e.g. us-east1, ap-northeast1"
         )]
         region: String,
     },
@@ -93,13 +92,13 @@ enum CloudSignupCommand {
         #[structopt(long, short)]
         email: String,
         #[structopt(
-        long,
-        short,
-        default_value = "us-west-2",
-        help = "e.g. us-west-2, us-east-1, ap-northeast-1"
+            long,
+            short,
+            default_value = "us-west-2",
+            help = "e.g. us-west-2, us-east-1, ap-northeast-1"
         )]
         region: String,
-    }
+    },
 }
 
 #[derive(Debug, StructOpt)]
@@ -226,14 +225,14 @@ async fn entrypoint() -> Result<(), CliError> {
             commands::configure::configure_cli::configure_momento(quick, &profile).await?
         }
         Subcommand::Account { operation } => match operation {
-            AccountCommand::Signup { signup_operation } =>  match signup_operation {
-                CloudSignupCommand::Gcp { email, region} => {
+            AccountCommand::Signup { signup_operation } => match signup_operation {
+                CloudSignupCommand::Gcp { email, region } => {
                     commands::account::signup_user(email, "gcp".to_string(), region).await?
                 }
-                CloudSignupCommand::Aws {email, region} => {
+                CloudSignupCommand::Aws { email, region } => {
                     commands::account::signup_user(email, "aws".to_string(), region).await?
                 }
-            }
+            },
             AccountCommand::CreateSigningKey {
                 ttl_minutes,
                 profile,


### PR DESCRIPTION
Signup
```
momento account signup gcp --email myemail@mydomain.com --region us-east1
```

This also updates the signup pattern for AWS, now it will be:
```
momento account signup aws --email myemail@mydomain.com --region us-west-2
```

Once, we agree upon the README in English. I will need help from @poppoerika to update the Japanese language README.
