### PR TITLE
feat: add support for ListSigningKeys API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,8 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
+ "time 0.1.44",
  "winapi",
 ]
 
@@ -655,11 +657,12 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8f0ad912280c5ed03aa3345ef2ae67dd9d54e99c1cf2ea10e3327703f38d6a"
+checksum = "29f048337ca301939302805d9a005c1e02fad98b1fd8d0dd949ff754bed0ea18"
 dependencies = [
  "base64-url",
+ "chrono",
  "jsonwebtoken",
  "prost",
  "rustls 0.19.1",
@@ -1316,7 +1319,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time",
+ "time 0.3.9",
 ]
 
 [[package]]
@@ -1426,6 +1429,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
 ]
 
 [[package]]
@@ -1808,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ toml = "0.5.8"
 maplit = "1.0.2"
 configparser = "3.0.0"
 regex = "1"
-momento = "0.2.2"
+momento = "0.3.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/src/commands/signingkey/signingkey_cli.rs
+++ b/src/commands/signingkey/signingkey_cli.rs
@@ -32,3 +32,18 @@ pub async fn revoke_signing_key(key_id: String, auth_token: String) -> Result<()
     };
     Ok(())
 }
+
+pub async fn list_signing_keys(auth_token: String) -> Result<(), CliError> {
+    debug!("listing signing keys...");
+    let mut momento = get_momento_instance(auth_token).await?;
+    match momento.list_signing_keys(None).await {
+        Ok(res) => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&res.signing_keys).unwrap()
+            );
+        }
+        Err(e) => return Err(CliError { msg: e.to_string() }),
+    };
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,6 +78,12 @@ enum AccountCommand {
         #[structopt(long, short, default_value = "default")]
         profile: String,
     },
+
+    #[structopt(about = "List all signing keys")]
+    ListSigningKeys {
+        #[structopt(long, short, default_value = "default")]
+        profile: String,
+    },
 }
 
 #[derive(Debug, StructOpt)]
@@ -223,6 +229,10 @@ async fn entrypoint() -> Result<(), CliError> {
                 )
                 .await?;
                 debug!("revoked signing key {}", key_id)
+            }
+            AccountCommand::ListSigningKeys { profile } => {
+                let (creds, _config) = get_creds_and_config(&profile).await?;
+                commands::signingkey::signingkey_cli::list_signing_keys(creds.token).await?;
             }
         },
     }


### PR DESCRIPTION
### Summary
Adds CLI support for new `ListSigningKeys` API. This also consumes the latest changes from the Rust SDK to display a Momento signing key's `expires_at` field as a UTC timestamp.

### Testing
* Create a signing key to demonstrate new `expires_at` return value
```sh
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹signing-keys*› » ./target/debug/momento account create-signing-key --ttl 30 --profile personal-prod
{
  "key_id": "5fhrnelif",
  "key": "<redacted>",
  "expires_at": "2022-04-22T23:04:17Z",
  "endpoint": "cache.cell-external-beta-1.prod.a.momentohq.com"
}
```

* List my account's signing keys
```sh
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹signing-keys*› » ./target/debug/momento account list-signing-keys --profile personal-prod
[
  {
    "key_id": "qhyssqxro",
    "expires_at": "2022-04-22T23:00:59Z",
    "endpoint": "cache.cell-external-beta-1.prod.a.momentohq.com"
  },
  {
    "key_id": "o7r4klx3z",
    "expires_at": "2022-04-22T22:55:28Z",
    "endpoint": "cache.cell-external-beta-1.prod.a.momentohq.com"
  },
  {
    "key_id": "5fhrnelif",
    "expires_at": "2022-04-22T23:04:17Z",
    "endpoint": "cache.cell-external-beta-1.prod.a.momentohq.com"
  }
]
```

* **Extra bonus!** Since we are returning this as a pretty-printed JSON response we can use `jq` to easily consume our values. For instance, now I can automatically revoke all my signing keys with `jq` and `xargs`:
```sh
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹signing-keys*› » ./target/debug/momento account list-signing-keys --profile personal-prod | jq '.[].key_id' | xargs -L1 -I'{}' ./target/debug/momento account revoke-signing-key --key-id '{}' --profile personal-prod
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹signing-keys*› » ./target/debug/momento account list-signing-keys --profile personal-prod
[]
Tylers-MacBook-Pro :: ~/repo/momento-cli ‹signing-keys*› »
```
