### PR TITLE
feat: add `login` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +250,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "configparser"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +280,41 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "difflib"
@@ -531,6 +582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +643,26 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
@@ -703,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431bdfdeea355427ae190ceb532ebd6211064dba4de5c8c58a03f9bf4b27c4a3"
+checksum = "1ec379e43f9cd7a835ca444d9a67abe574b4c1d2ded3ada42f18d22115090bcd"
 dependencies = [
  "chrono",
  "jsonwebtoken",
@@ -737,6 +814,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing-subscriber",
+ "webbrowser",
 ]
 
 [[package]]
@@ -755,6 +833,62 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "ndk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2032c77e030ddee34a6787a64166008da93f6a352b629261d0fee232b8742dd4"
+dependencies = [
+ "bitflags",
+ "jni-sys",
+ "ndk-sys",
+ "num_enum",
+ "thiserror",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-glue"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0c4a7b83860226e6b4183edac21851f05d5a51756e97a1144b7f5a6b63e65f"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-macro",
+ "ndk-sys",
+]
+
+[[package]]
+name = "ndk-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ntapi"
@@ -803,6 +937,27 @@ checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -958,6 +1113,16 @@ checksum = "d9e07e3a46d0771a8a06b5f4441527802830b43e679ba12f44960f48dd4c6803"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -1240,6 +1405,15 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1877,6 +2051,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2154,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a3cffdb686fbb24d9fb8f03a213803277ed2300f11026a3afe1f108dc021b"
+dependencies = [
+ "jni",
+ "ndk-glue",
+ "url",
+ "web-sys",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2196,12 @@ dependencies = [
  "lazy_static",
  "libc",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ toml = "0.5.8"
 maplit = "1.0.2"
 configparser = "3.0.0"
 regex = "1"
-momento = "0.5.0"
+momento = "0.5.1"
+webbrowser = "0.7.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,0 +1,23 @@
+use momento::momento::auth::LoginResult;
+
+pub async fn login() -> LoginResult {
+    momento::momento::auth::login(|action| {
+        match action {
+            momento::momento::auth::LoginAction::OpenBrowser(open) => {
+                // TODO: Need an early-out from the action sink.
+                // match webbrowser::open(&open.url) {
+                //     Ok(_) => {
+                //         log::debug!("opened browser to {}", open.url);
+                //     },
+                //     Err(e) => {
+                //         return LoginResult::NotLoggedIn(NotLoggedIn { error_message: e.to_string })
+                //     },
+                // }
+                webbrowser::open(&open.url).expect("Unable to open browser")
+            },
+            momento::momento::auth::LoginAction::ShowMessage(message) => {
+                println!("{}", message.text);
+            },
+        }
+    }).await
+}

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -14,10 +14,11 @@ pub async fn login() -> LoginResult {
                 //     },
                 // }
                 webbrowser::open(&open.url).expect("Unable to open browser")
-            },
+            }
             momento::momento::auth::LoginAction::ShowMessage(message) => {
                 println!("{}", message.text);
-            },
+            }
         }
-    }).await
+    })
+    .await
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod account;
 pub mod cache;
 pub mod configure;
+pub mod login;
 pub mod signingkey;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,7 @@ enum Subcommand {
         operation: AccountCommand,
     },
     #[structopt(about = "Log in to manage your Momento account")]
-    Login {
-    }
+    Login {},
 }
 
 #[derive(Debug, StructOpt)]
@@ -254,14 +253,14 @@ async fn entrypoint() -> Result<(), CliError> {
                 commands::signingkey::signingkey_cli::list_signing_keys(creds.token).await?;
             }
         },
-        Subcommand::Login {  } => {
-            match commands::login::login().await {
-                momento::momento::auth::LoginResult::LoggedIn(logged_in) => {
-                    println!("{}", logged_in.session_token)
-                },
-                momento::momento::auth::LoginResult::NotLoggedIn(not_logged_in) => {
-                    return Err(CliError { msg: format!("Failed to log in: {}", not_logged_in.error_message) })
-                },
+        Subcommand::Login {} => match commands::login::login().await {
+            momento::momento::auth::LoginResult::LoggedIn(logged_in) => {
+                println!("{}", logged_in.session_token)
+            }
+            momento::momento::auth::LoginResult::NotLoggedIn(not_logged_in) => {
+                return Err(CliError {
+                    msg: format!("Failed to log in: {}", not_logged_in.error_message),
+                })
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,9 @@ enum Subcommand {
         #[structopt(subcommand)]
         operation: AccountCommand,
     },
-    #[structopt(about = "Log in to manage your Momento account")]
+    #[structopt(
+        about = "*Construction Zone* We're working on this! *Construction Zone* Log in to manage your Momento account"
+    )]
     Login {},
 }
 
@@ -259,7 +261,7 @@ async fn entrypoint() -> Result<(), CliError> {
             }
             momento::momento::auth::LoginResult::NotLoggedIn(not_logged_in) => {
                 return Err(CliError {
-                    msg: format!("Failed to log in: {}", not_logged_in.error_message),
+                    msg: not_logged_in.error_message,
                 })
             }
         },


### PR DESCRIPTION
Adds `momento login` command for doing SSO. The integration has
a live connection back up to the Momento endpoint that it running
the login workflow.

A standard oauth dance happens, with a browser opening up to an
SSO page. Some infos are printed from the server while you're
logging in, then the login credentials are printed to stdout.

We will be moving this session token to a momento dotfile, but
this change gets the SSO integration started. Not many endpoints
are supported, but over time we'll add more.
