### PR TITLE
feat: store session tokens in .momento_session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec379e43f9cd7a835ca444d9a67abe574b4c1d2ded3ada42f18d22115090bcd"
+checksum = "874dd9d49adf223f60515bc3008c173fe408657ecb82473560d0877ae88554e1"
 dependencies = [
  "chrono",
  "jsonwebtoken",
@@ -799,6 +799,7 @@ name = "momento-cli"
 version = "0.11.9"
 dependencies = [
  "assert_cmd",
+ "chrono",
  "clap",
  "colored",
  "configparser",
@@ -819,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e75ce56191eb20358b7e2ba26bc11d19abc087e9f78c568e24ea4c4476cd2ca6"
+checksum = "426dadd39866ada5146d0a7bace63a09de83c5b892847905ec2bc0379455fbd2"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ version = "0.11.9"
 edition = "2021"
 
 [dependencies]
+chrono = "0.4.19"
 colored = "2.0.0"
 home = "0.5.3"
 toml = "0.5.8"
 maplit = "1.0.2"
 configparser = "3.0.0"
 regex = "1"
-momento = "0.5.1"
+momento = "0.5.4"
 webbrowser = "0.7.1"
 
 [dev-dependencies]

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,22 +1,24 @@
-use momento::momento::auth::LoginResult;
+use momento::{momento::auth::LoginResult, response::error::MomentoError};
 
 pub async fn login() -> LoginResult {
     momento::momento::auth::login(|action| {
         match action {
             momento::momento::auth::LoginAction::OpenBrowser(open) => {
-                // TODO: Need an early-out from the action sink.
-                // match webbrowser::open(&open.url) {
-                //     Ok(_) => {
-                //         log::debug!("opened browser to {}", open.url);
-                //     },
-                //     Err(e) => {
-                //         return LoginResult::NotLoggedIn(NotLoggedIn { error_message: e.to_string })
-                //     },
-                // }
-                webbrowser::open(&open.url).expect("Unable to open browser")
+                match webbrowser::open(&open.url) {
+                    Ok(_) => {
+                        log::debug!("opened browser to {}", open.url);
+                        None
+                    },
+                    Err(e) => {
+                        Some(
+                            Err(MomentoError::ClientSdkError(format!("Unable to open browser: {:?}", e)))
+                        )
+                    },
+                }
             }
             momento::momento::auth::LoginAction::ShowMessage(message) => {
-                println!("{}", message.text);
+                eprintln!("{}", message.text);
+                None
             }
         }
     })

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,25 +1,22 @@
 use momento::{momento::auth::LoginResult, response::error::MomentoError};
 
 pub async fn login() -> LoginResult {
-    momento::momento::auth::login(|action| {
-        match action {
-            momento::momento::auth::LoginAction::OpenBrowser(open) => {
-                match webbrowser::open(&open.url) {
-                    Ok(_) => {
-                        log::debug!("opened browser to {}", open.url);
-                        None
-                    },
-                    Err(e) => {
-                        Some(
-                            Err(MomentoError::ClientSdkError(format!("Unable to open browser: {:?}", e)))
-                        )
-                    },
+    momento::momento::auth::login(|action| match action {
+        momento::momento::auth::LoginAction::OpenBrowser(open) => {
+            match webbrowser::open(&open.url) {
+                Ok(_) => {
+                    log::debug!("opened browser to {}", open.url);
+                    None
                 }
+                Err(e) => Some(Err(MomentoError::ClientSdkError(format!(
+                    "Unable to open browser: {:?}",
+                    e
+                )))),
             }
-            momento::momento::auth::LoginAction::ShowMessage(message) => {
-                eprintln!("{}", message.text);
-                None
-            }
+        }
+        momento::momento::auth::LoginAction::ShowMessage(message) => {
+            eprintln!("{}", message.text);
+            None
         }
     })
     .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ pub struct Config {
     pub ttl: u64,
 }
 
-#[derive(Deserialize, Serialize, Clone, Default)]
+#[derive(Deserialize, Serialize, Clone, Default, Debug)]
 pub struct Credentials {
     pub token: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use error::CliError;
 use log::{debug, error};
 use utils::user::get_creds_and_config;
 
+use crate::utils::user::clobber_session_token;
+
 mod commands;
 mod config;
 mod error;
@@ -252,12 +254,14 @@ async fn entrypoint() -> Result<(), CliError> {
             }
             AccountCommand::ListSigningKeys { profile } => {
                 let (creds, _config) = get_creds_and_config(&profile).await?;
-                commands::signingkey::signingkey_cli::list_signing_keys(creds.token).await?;
+                commands::signingkey::signingkey_cli::list_signing_keys(creds.token).await?
             }
         },
         Subcommand::Login {} => match commands::login::login().await {
             momento::momento::auth::LoginResult::LoggedIn(logged_in) => {
-                println!("{}", logged_in.session_token)
+                debug!("{}", logged_in.session_token);
+                clobber_session_token(Some(logged_in.session_token.to_string()), logged_in.valid_for_seconds).await?;
+                eprintln!("Login valid for {}m", logged_in.valid_for_seconds / 60)
             }
             momento::momento::auth::LoginResult::NotLoggedIn(not_logged_in) => {
                 return Err(CliError {

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,11 @@ async fn entrypoint() -> Result<(), CliError> {
         Subcommand::Login {} => match commands::login::login().await {
             momento::momento::auth::LoginResult::LoggedIn(logged_in) => {
                 debug!("{}", logged_in.session_token);
-                clobber_session_token(Some(logged_in.session_token.to_string()), logged_in.valid_for_seconds).await?;
+                clobber_session_token(
+                    Some(logged_in.session_token.to_string()),
+                    logged_in.valid_for_seconds,
+                )
+                .await?;
                 eprintln!("Login valid for {}m", logged_in.valid_for_seconds / 60)
             }
             momento::momento::auth::LoginResult::NotLoggedIn(not_logged_in) => {

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -46,7 +46,6 @@ pub async fn clobber_session_token(session_token: Option<String>, valid_for_seco
 
 pub async fn get_creds_and_config(profile: &str) -> Result<(Credentials, Config), CliError> {
     let creds = get_creds_for_profile(profile).await?;
-    println!("CREDS {:?}", creds);
     let config = get_config_for_profile(profile).await?;
 
     Ok((creds, config))

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -1,42 +1,76 @@
+use chrono::{Utc, Duration, TimeZone};
+use configparser::ini::Ini;
+
 use crate::{
     config::{Config, Credentials},
     error::CliError,
     utils::file::{get_config_file_path, get_credentials_file_path, read_file},
 };
 
+use super::file::ini_write_to_file;
+
+fn get_session_token(credentials: &Ini) -> Option<String> {
+    let session_token = credentials.get(".momento_session", "token");
+    if session_token.is_some() {
+        let expiry = credentials
+            .get(".momento_session", "valid_until")
+            .map(|s| { s.parse::<i64>().unwrap_or(0) })
+            .map(|expiry_timestamp| { Utc.timestamp(expiry_timestamp, 0) });
+        if let Some(expiry_timestamp) = expiry {
+            if Utc::now() + Duration::seconds(10) < expiry_timestamp {
+                let expiring = expiry_timestamp - Utc::now();
+                log::debug!("Found user session expiring in {}m", expiring.num_minutes());
+                return session_token;
+            }
+            log::debug!("Token already expired at: {}", expiry_timestamp);
+        } else {
+            log::debug!(".momento_session profile is missing the expiry time. Skipping this session...");
+        }
+    }
+    log::debug!("No session found in .momento_session profile...");
+    None
+}
+
+fn set_session_token(credentials: &mut Ini, session_token: Option<String>, valid_for_seconds: u32) {
+    let expiry_time = Utc::now() + Duration::seconds(valid_for_seconds.into());
+    credentials.set(".momento_session", "token", session_token);
+    credentials.set(".momento_session", "valid_until", Some(expiry_time.timestamp().to_string()));
+}
+
+pub async fn clobber_session_token(session_token: Option<String>, valid_for_seconds: u32) -> Result<(), CliError> {
+    let mut credentials_file = read_credentials().await?;
+    set_session_token(&mut credentials_file, session_token, valid_for_seconds);
+    ini_write_to_file(credentials_file, &get_credentials_file_path()).await?;
+    Ok(())
+}
+
 pub async fn get_creds_and_config(profile: &str) -> Result<(Credentials, Config), CliError> {
-    let creds = match get_creds_for_profile(profile).await {
-        Ok(c) => c,
-        Err(e) => return Err(e),
-    };
-    let config = match get_config_for_profile(profile).await {
-        Ok(c) => c,
-        Err(e) => return Err(e),
-    };
+    let creds = get_creds_for_profile(profile).await?;
+    println!("CREDS {:?}", creds);
+    let config = get_config_for_profile(profile).await?;
 
     Ok((creds, config))
 }
 
 pub async fn get_creds_for_profile(profile: &str) -> Result<Credentials, CliError> {
-    let path = get_credentials_file_path();
-    let credentials = match read_file(&path).await {
-        Ok(c) => c,
-        Err(_) => return Err(CliError {
-            msg: "failed to read credentials, please run 'momento configure' to setup credentials"
-                .to_string(),
-        }),
-    };
+    let credentials_file = read_credentials().await?;
 
-    let creds_result = match credentials.get(profile, "token") {
-        Some(c) => c,
-        None => return Err(CliError{
+    get_session_token(&credentials_file).or_else(|| {
+        credentials_file.get(profile, "token")
+    }).map(|credentials| {
+        Ok(Credentials {
+            token: credentials,
+        })
+    }).unwrap_or_else(|| {
+        Err(CliError{
             msg: format!("failed to get credentials for profile {}, please run 'momento configure' to configure your profile", profile)
-        }),
-    };
-
-    Ok(Credentials {
-        token: creds_result,
+        })
     })
+}
+
+async fn read_credentials() -> Result<Ini, CliError> {
+    let path = get_credentials_file_path();
+    read_file(&path).await
 }
 
 pub async fn get_config_for_profile(profile: &str) -> Result<Config, CliError> {


### PR DESCRIPTION
Also uses sessions if they're valid for at least 10 more seconds.
This breaks interactions with the service currently if you have
an active login session, because session tokens do not have the
momento endpoints baked into them.
