### PR TITLE
fix: broken brew update command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ momento cache get --key key --name example-cache
 ## Upgrading
 
 ```
-brew update
 brew upgrade momento-cli
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ momento cache get --key key --name example-cache
 ## Upgrading
 
 ```
-brew update momento-cli
+brew update
 brew upgrade momento-cli
 ```
 


### PR DESCRIPTION
The command `brew update momento-cli` fails with an error: 
```
Error: This command updates brew itself, and does not take formula names.
Use `brew upgrade momento-cli` instead.
```

I think we need just `brew update`.  I don't like this because it potentially touches a bunch of stuff that a user isn't trying to upgrade, but it won't work if you pass it a formula name, and I don't know how to update a single formula, and I don't think the `brew upgrade momento-cli` command actually works without the `update` before it?