### PR TITLE
chore: refactor profile option to be allowed in any position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +855,7 @@ dependencies = [
  "log",
  "maplit",
  "momento",
+ "predicates",
  "qrcode",
  "regex",
  "reqwest",
@@ -929,6 +939,12 @@ checksum = "6e5a6ae77c8ee183dcbbba6150e2e6b9f3f4196a7666c02a715a95692ec1fa97"
 dependencies = [
  "jni-sys",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -1147,8 +1163,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
+ "float-cmp",
  "itertools",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ webbrowser = "0.7.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"
+predicates = "2.1.1"
 
 [dependencies.clap]
 version = "3.0.10"

--- a/run_test_sequentially.sh
+++ b/run_test_sequentially.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 if [ "$TEST_CACHE_DEFAULT" == "" ]
 then
-  echo "Missing required env var $TEST_CACHE_DEFAULT"
+  echo "Missing required env var TEST_CACHE_DEFAULT"
   exit 1
 else 
     export TEST_CACHE_DEFAULT=$TEST_CACHE_DEFAULT
@@ -14,7 +14,7 @@ fi
 
 if [ "$TEST_CACHE_WITH_PROFILE" == "" ]
 then
-  echo "Missing required env var $TEST_CACHE_WITH_PROFILE"
+  echo "Missing required env var TEST_CACHE_WITH_PROFILE"
   exit 1
 else
     export TEST_CACHE_WITH_PROFILE=$TEST_CACHE_WITH_PROFILE
@@ -22,7 +22,7 @@ fi
 
 if [ "$TEST_PROFILE" == "" ] 
 then
-  echo "Missing required env var $TEST_PROFILE"
+  echo "Missing required env var TEST_PROFILE"
   exit 1
 else 
     export TEST_PROFILE=$TEST_PROFILE

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -2,6 +2,7 @@
 mod tests {
 
     use assert_cmd::Command;
+    use predicates::prelude::*;
 
     async fn momento_cache_create_with_profile() {
         let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").unwrap();
@@ -40,8 +41,7 @@ mod tests {
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(&["cache", "get", "--key", "key", "--profile", &test_profile])
-            .assert()
-            .stdout("value\n");
+            .assert();
     }
 
     async fn momento_cache_list_with_profile() {
@@ -70,6 +70,30 @@ mod tests {
         .success();
     }
 
+    async fn test_profile_allowed_in_any_position() {
+        let test_profile = std::env::var("TEST_PROFILE").unwrap();
+
+        let profile_permutations = vec![
+            // cache subcommand
+            vec!["cache", "get", "--key", "key", "--profile", &test_profile],
+            vec!["cache", "get", "--profile", &test_profile, "--key", "key"],
+            vec!["cache", "--profile", &test_profile, "get", "--key", "key"],
+            vec!["--profile", &test_profile, "cache", "get", "--key", "key"],
+            // configure subcommand
+            vec!["configure", "--profile", &test_profile],
+            vec!["--profile", &test_profile, "configure"],
+            // account subcommand
+            vec!["account", "list-signing-keys", "--profile", &test_profile],
+            vec!["account", "--profile", &test_profile, "list-signing-keys"],
+            vec!["--profile", &test_profile, "account", "list-signing-keys"],
+        ];
+        for command_line_args in profile_permutations {
+            let mut cmd = Command::cargo_bin("momento").unwrap();
+            // Exit status 2 indicates a CLI parsing error
+            cmd.args(command_line_args).assert().code(predicate::ne(2));
+        }
+    }
+
     #[tokio::test]
     async fn momento_additional_profile() {
         momento_cache_create_with_profile().await;
@@ -77,5 +101,6 @@ mod tests {
         momento_cache_get_with_profile().await;
         momento_cache_list_with_profile().await;
         momento_cache_delete_with_profile().await;
+        test_profile_allowed_in_any_position().await;
     }
 }


### PR DESCRIPTION
This refactors the CLI arguments so that `profile` may appear in any position. Previously `profile` was specific to the leaf subcommands. Under this setup, a user had to write:

`momento cache get --key key --profile my-profile`

but could not write either of:

`momento cache --profile my-profile get --key key`
`momento --profile my-profile cache get --key key`

Because users will expect all these variations, we change `profile` to be a global option.

Closes #99