### PR TITLE
fix: display available regions for aws/gcp for better error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,14 +101,14 @@ enum CloudSignupCommand {
     Gcp {
         #[structopt(long, short)]
         email: String,
-        #[structopt(long, short, help = "e.g. us-east1, ap-northeast1")]
+        #[structopt(long, short, possible_values = ["us-east1", "ap-northeast1"], value_name = "us-east1 or ap-northeast1")]
         region: String,
     },
     #[structopt(about = "Signup for Momento on AWS")]
     Aws {
         #[structopt(long, short)]
         email: String,
-        #[structopt(long, short, help = "e.g. us-west-2, us-east-1, ap-northeast-1")]
+        #[structopt(long, short, possible_values = ["us-west-2", "us-east-1", "ap-northeast-1"], value_name = "us-west-2, us-east-1, or ap-northeast-1")]
         region: String,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,14 +101,14 @@ enum CloudSignupCommand {
     Gcp {
         #[structopt(long, short)]
         email: String,
-        #[structopt(long, short, possible_values = ["us-east1", "ap-northeast1"], value_name = "us-east1 or ap-northeast1")]
+        #[structopt(long, short, value_name = "us-east1 or ap-northeast1")]
         region: String,
     },
     #[structopt(about = "Signup for Momento on AWS")]
     Aws {
         #[structopt(long, short)]
         email: String,
-        #[structopt(long, short, possible_values = ["us-west-2", "us-east-1", "ap-northeast-1"], value_name = "us-west-2, us-east-1, or ap-northeast-1")]
+        #[structopt(long, short, value_name = "us-west-2, us-east-1, or ap-northeast-1")]
         region: String,
     },
 }


### PR DESCRIPTION
Closes #168 

### When user didn't pass `--region` flag; available regions are displayed 

Before
```
momento account signup gcp --email eem@momentohq.com
error: The following required arguments were not provided:
    --region <REGION>
```
After
```
target/debug/momento account signup gcp --email eem@momentohq.com
error: The following required arguments were not provided:
    --region <us-east1 or ap-northeast1>
```

### When user passed an invalid value for `--region`; possible values are displayed. Also, does not alert the cli-signup channel on Slack

Before
```
momento account signup aws --email eem@momentohq.com --region fgfs
[2022-10-13T04:37:39Z INFO  momento::commands::account] Signing up for Momento...
ERROR: Failed to create Momento token: Region 'fgfs' is not a valid region for AWS. The available regions are: us-west-2, us-east-1, ap-northeast-1
```
After
```
target/debug/momento account signup gcp
--email eem@momentohq.com --region dcasdfafaf
error: "dcasdfafaf" isn't a valid value for '--region <us-east1 or ap-northeast1>'
	[possible values: ap-northeast1, us-east1]
```

### When user didn't pass any value to `--region` flag; availabe regions are displayed in the error message

Before
```
momento account signup aws --email eem@momentohq.com --region
error: The argument '--region <REGION>' requires a value but none was supplied
```
After
```
target/debug/momento account signup gcp --email eem@momentohq.com --region
error: The argument '--region <us-east1 or ap-northeast1>' requires a value but none was supplied
```