### PR TITLE
chore: only use logging when verbose

### DIFF
--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -1,9 +1,8 @@
-use log::info;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::env;
 
-use crate::error::CliError;
+use crate::{error::CliError, utils::console::console_info};
 
 const SIGNUP_ENDPOINT: &str = "https://signup.registry.prod.a.momentohq.com";
 
@@ -40,11 +39,11 @@ pub async fn signup_user(email: String, cloud: String, region: String) -> Result
         cloud,
         region,
     };
-    info!("Signing up for Momento...");
+    console_info!("Signing up for Momento...");
     match Client::new().post(url).json(body).send().await {
         Ok(resp) => {
             if resp.status().is_success() {
-                info!("Success! Your access token will be emailed to you shortly.")
+                console_info!("Success! Your access token will be emailed to you shortly.")
             } else {
                 let response_json: CreateTokenResponse = resp.json().await.unwrap_or_default();
                 return Err(CliError {

--- a/src/commands/cache/cache_cli.rs
+++ b/src/commands/cache/cache_cli.rs
@@ -2,8 +2,13 @@ use log::debug;
 use std::num::NonZeroU64;
 use std::process::exit;
 
-use crate::error::CliError;
-use crate::utils::client::{get_momento_client, interact_with_momento};
+use crate::{
+    error::CliError,
+    utils::{
+        client::{get_momento_client, interact_with_momento},
+        console::console_data,
+    },
+};
 
 pub async fn create_cache(
     cache_name: String,
@@ -33,7 +38,7 @@ pub async fn list_caches(auth_token: String, endpoint: Option<String>) -> Result
     list_result
         .caches
         .into_iter()
-        .for_each(|cache| println!("{}", cache.cache_name));
+        .for_each(|cache| console_data!("{}", cache.cache_name));
 
     Ok(())
 }
@@ -75,7 +80,7 @@ pub async fn get(
     let response = interact_with_momento("getting...", client.get(&cache_name, key)).await?;
     match response.result {
         momento::response::cache_get_response::MomentoGetStatus::HIT => {
-            println!("{}", response.as_string())
+            console_data!("{}", response.as_string())
         }
         momento::response::cache_get_response::MomentoGetStatus::MISS => {
             debug!("cache miss");

--- a/src/commands/configure/configure_cli.rs
+++ b/src/commands/configure/configure_cli.rs
@@ -1,4 +1,3 @@
-use log::info;
 use std::path::Path;
 use tokio::fs;
 
@@ -7,6 +6,7 @@ use crate::{
     config::{Config, Credentials, FileTypes},
     error::CliError,
     utils::{
+        console::console_info,
         file::{
             create_file, get_config_file_path, get_credentials_file_path, get_momento_dir,
             open_file, prompt_user_for_input, read_file_contents, write_to_file,
@@ -60,14 +60,14 @@ pub async fn configure_momento(quick: bool, profile_name: &str) -> Result<(), Cl
     }
     // TODO: Update the endpoint to read from config
     match create_cache(config.cache.clone(), credentials.token, None).await {
-        Ok(_) => info!(
+        Ok(_) => console_info!(
             "{} successfully created as the default with default TTL of {}s",
             config.cache.clone(),
             config.ttl
         ),
         Err(e) => {
             if e.msg.contains("already exists") {
-                info!("{} as the default already exists", config.cache);
+                console_info!("{} as the default already exists", config.cache);
             } else {
                 return Err(e);
             }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,8 +1,8 @@
+use crate::utils::console::console_info;
 use momento::momento::auth::{EarlyOutActionResult, LoginAction};
 use momento::{momento::auth::LoginResult, response::error::MomentoError};
 use qrcode::render::unicode;
 use qrcode::QrCode;
-use crate::utils::console::console_info;
 
 #[derive(clap::ArgEnum, Clone, Debug)]
 pub enum LoginMode {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -2,7 +2,7 @@ use momento::momento::auth::{EarlyOutActionResult, LoginAction};
 use momento::{momento::auth::LoginResult, response::error::MomentoError};
 use qrcode::render::unicode;
 use qrcode::QrCode;
-use utils::console::console_info;
+use crate::utils::console::console_info;
 
 #[derive(clap::ArgEnum, Clone, Debug)]
 pub enum LoginMode {

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -2,6 +2,7 @@ use momento::momento::auth::{EarlyOutActionResult, LoginAction};
 use momento::{momento::auth::LoginResult, response::error::MomentoError};
 use qrcode::render::unicode;
 use qrcode::QrCode;
+use utils::console::console_info;
 
 #[derive(clap::ArgEnum, Clone, Debug)]
 pub enum LoginMode {
@@ -32,7 +33,7 @@ fn login_with_browser(action: LoginAction) -> EarlyOutActionResult {
             }
         }
         momento::momento::auth::LoginAction::ShowMessage(message) => {
-            eprintln!("{}", message.text);
+            console_info!("{}", message.text);
             None
         }
     }
@@ -41,18 +42,18 @@ fn login_with_browser(action: LoginAction) -> EarlyOutActionResult {
 fn login_with_qr_code(action: LoginAction) -> EarlyOutActionResult {
     match action {
         momento::momento::auth::LoginAction::OpenBrowser(open) => {
-            eprintln!("Navigate here to log in: {}", open.url);
+            console_info!("Navigate here to log in: {}", open.url);
             let code = QrCode::new(open.url).unwrap();
             let image = code
                 .render::<unicode::Dense1x2>()
                 .dark_color(unicode::Dense1x2::Dark)
                 .light_color(unicode::Dense1x2::Light)
                 .build();
-            eprintln!("{}", image);
+            console_info!("{}", image);
             None
         }
         momento::momento::auth::LoginAction::ShowMessage(message) => {
-            eprintln!("{}", message.text);
+            console_info!("{}", message.text);
             None
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use clap::StructOpt;
 use commands::login::LoginMode;
 use env_logger::Env;
 use error::CliError;
-use log::{debug, error};
+use log::{debug, error, LevelFilter};
+use utils::console::console_info;
 use utils::user::get_creds_and_config;
 
 #[cfg(feature = "login")]
@@ -185,7 +186,12 @@ enum CacheCommand {
 async fn entrypoint() -> Result<(), CliError> {
     let args = Momento::parse();
 
-    let log_level = if args.verbose { "debug" } else { "info" };
+    let log_level = if args.verbose {
+        LevelFilter::Debug
+    } else {
+        LevelFilter::Off
+    }
+    .as_str();
 
     env_logger::Builder::from_env(
         Env::default()
@@ -300,7 +306,7 @@ async fn entrypoint() -> Result<(), CliError> {
                     logged_in.valid_for_seconds,
                 )
                 .await?;
-                eprintln!("Login valid for {}m", logged_in.valid_for_seconds / 60)
+                console_info!("Login valid for {}m", logged_in.valid_for_seconds / 60);
             }
             momento::momento::auth::LoginResult::NotLoggedIn(not_logged_in) => {
                 return Err(CliError {
@@ -319,7 +325,7 @@ async fn main() {
     }));
 
     if let Err(e) = entrypoint().await {
-        eprintln!("{}", e);
+        console_info!("{}", e);
         exit(1)
     }
 }

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -5,7 +5,7 @@ use momento::{
     simple_cache_client::{SimpleCacheClient, SimpleCacheClientBuilder},
 };
 
-use crate::error::CliError;
+use crate::{error::CliError, utils::console::console_data};
 
 pub async fn get_momento_client(
     auth_token: String,
@@ -31,7 +31,7 @@ pub fn print_whatever_this_is_as_json<T>(value: &T)
 where
     T: serde::Serialize,
 {
-    println!(
+    console_data!(
         "{}",
         serde_json::to_string_pretty(value).expect("Could not print whatever this is as json")
     );

--- a/src/utils/console.rs
+++ b/src/utils/console.rs
@@ -1,0 +1,66 @@
+/// Write an `info` level `&str` to the console.
+///
+/// Since we reserve detailed log messages when the cli is `verbose`,
+/// we funnel any other console messages here (thus to `stderr`).
+///
+/// # Examples
+/// ```
+/// output_info("Hello, world!");
+/// //stderr> Hello, world!
+/// ```
+pub fn output_info(msg: &str) {
+    eprintln!("{}", msg);
+}
+
+/// The console print macro for non-verbose output.
+///
+/// This macro will print to the console with a `format!`
+/// based argument list.
+///
+/// # Examples
+///
+/// ```
+/// console_info!("Hello, world!");
+/// console_info!("My name is {}", "Momento");
+/// ```
+macro_rules! console_info {
+    () => ($crate::utils::console::output_info(""));
+    ($($a:tt)*) => {{
+        $crate::utils::console::output_info(&format!($($a)*));
+    }};
+}
+
+pub(crate) use console_info;
+
+// Write cache data `&str` to the console.
+//
+// Since we reserve detailed log messages when the cli is `verbose`,
+// we funnel any other console messages for cache data here (thus to `stdout`).
+//
+// # Examples
+// ```
+// output_data("{\"key\": \"value\"}");
+// //> {"key": "value"}
+// ```
+pub fn output_data(msg: &str) {
+    println!("{}", msg);
+}
+
+/// The console print macro for cache response data.
+///
+/// This macro will print to the console with a `format!`
+/// based argument list.
+///
+/// # Examples
+///
+/// ```
+/// console_data!("{\"key\": \"my-key\", \"value\": \"my-value\"}");
+/// ```
+macro_rules! console_data {
+    () => ($crate::utils::console::output_data(""));
+    ($($a:tt)*) => {{
+        $crate::utils::console::output_data(&format!($($a)*));
+    }};
+}
+
+pub(crate) use console_data;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod console;
 pub mod file;
 pub mod ini_config;
 pub mod user;


### PR DESCRIPTION
This turns off logging when not verbose. Verbose logging is set to `debug` level. As discussed in #172 we find the log data _too_ verbose compared to the other status messages or normal cache response data.

We replace other print statements with one of two new macros.

We funnel all status or error print statements to `stderr` with `console_info!`. Similarly we define a macro `console_data!` for cache response data, which we print to `stdout`.

Closes #172