### PR TITLE
fix: add release step to pass release version

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -87,15 +87,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt, build, build-windows]
     steps:
+      - name: Dry run release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true
+          force-bump-patch-version: true
+          dry: true
       - uses: actions/checkout@v2
       - name: Update Cargo Version
         run: |
           chmod +x set_cargo_version.sh
-          ./set_cargo_version.sh ${{ needs.release.outputs.version }}
+          ./set_cargo_version.sh ${{ steps.semrel.outputs.version }}
           git config user.email "momentobot@users.noreply.github.com"
           git config user.name "momentobot"
           git add Cargo.toml
-          git commit -m "chore: bump cargo version v${{ needs.release.outputs.version }}"
+          git commit -m "chore: bump cargo version v${{ steps.semrel.outputs.version }}"
         shell: bash
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -87,6 +87,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [rustfmt, build, build-windows]
     steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
       - name: Dry run release
         id: semrel
         uses: go-semantic-release/action@v1


### PR DESCRIPTION
This is to fix the test failure on the `on-push-to-main` workflow. 
A release version argument was missing from the `update-cargo` job, so added dry run release step to generate a release version and pass it to the `set_cargo_version` script.
Also added a step to set up python to run the `set_cargo_version` script successfully. 

Ticket #177 