### PR TITLE
fix: remove dry run from semrel step

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -42,7 +42,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           force-bump-patch-version: true
-          dry: true
 
       - name: Update Cargo Version
         run: |


### PR DESCRIPTION
When `main` tried to be merged into `release`, a release version was missing from `Update Cargo Version` step in `on-push-to-release` workflow, so removed `dry-run` option from semrel.

Related: https://github.com/momentohq/momento-cli/issues/177