### PR TITLE
fix: pass custom arg to run semrel on non default branch

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -42,6 +42,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           force-bump-patch-version: true
+          dry: true
+          # For whatever reason, this silly tool won't let you do releases from branches
+          #  other than the default branch unless you pass this flag, which doesn't seem
+          #  to actually have anything to do with CI:
+          # https://github.com/go-semantic-release/semantic-release/blob/master/cmd/semantic-release/main.go#L173-L194
+          # https://github.com/go-semantic-release/condition-github/blob/4c8af3fc516151423fff2f77eb08bf7082570676/pkg/condition/github.go#L42-L44
+          custom-arguments: "--no-ci"
 
       - name: Update Cargo Version
         run: |


### PR DESCRIPTION
Needs to pass `--no-ci` flag to run semrel on non-default branch (in our case `release`)

