### PR TITLE
fix: add custom arg to semrel release step to run this step in non-main branch

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -110,6 +110,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true
           force-bump-patch-version: true
+          custom-arguments: "--no-ci"
 
   publish-linux-assets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is one more step to add a semrel custom arg to run the release step on `release` branch.