### PR TITLE
fix: add one more param to `needs` in publishing assets jobs on release

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         feature: [default, login]
 

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         feature: [default, login]
 

--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -102,11 +102,31 @@ jobs:
         id: release
         run: echo "::set-output name=release::${{ steps.semrel.outputs.version }}"
 
+  update-cargo:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update Cargo Version
+        run: |
+          chmod +x set_cargo_version.sh
+          ./set_cargo_version.sh ${{ needs.release.outputs.version }}
+          git config user.email "momentobot@users.noreply.github.com"
+          git config user.name "momentobot"
+          git add Cargo.toml
+          git commit -m "chore: bump cargo version v${{ needs.release.outputs.version }}"
+        shell: bash
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+
   publish-linux-assets:
     runs-on: ubuntu-latest
     container:
       image: quay.io/pypa/manylinux2014_x86_64
-    needs: release
+    needs: [release, update-cargo]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -132,7 +152,7 @@ jobs:
 
   publish-windows-assets:
     runs-on: windows-latest
-    needs: release
+    needs: [release, update-cargo]
     steps:
       - uses: actions/checkout@v2
       - name: i guess windows-latest does not have protoc or cmake but we need protoc
@@ -214,23 +234,3 @@ jobs:
       #     asset_path: ${{ steps.create_release_32.outputs.asset_path }}
       #     asset_name: ${{ steps.create_release_32.outputs.asset_name }}
       #     asset_content_type: application/zip
-
-  update-cargo:
-    runs-on: ubuntu-latest
-    needs: release
-    steps:
-      - uses: actions/checkout@v2
-      - name: Update Cargo Version
-        run: |
-          chmod +x set_cargo_version.sh
-          ./set_cargo_version.sh ${{ needs.release.outputs.version }}
-          git config user.email "momentobot@users.noreply.github.com"
-          git config user.name "momentobot"
-          git add Cargo.toml
-          git commit -m "chore: bump cargo version v${{ needs.release.outputs.version }}"
-        shell: bash
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}

--- a/tests/configure_profiles_test.rs
+++ b/tests/configure_profiles_test.rs
@@ -6,7 +6,7 @@ mod tests {
     async fn configure_momento_default_profile() {
         let test_auth_token = std::env::var("TEST_AUTH_TOKEN_DEFAULT").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["configure"])
+        cmd.args(["configure"])
             .write_stdin(test_auth_token)
             .assert()
             .success();
@@ -14,14 +14,14 @@ mod tests {
 
     async fn momento_cache_set_default_profile() {
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "set", "--key", "key", "--value", "value"])
+        cmd.args(["cache", "set", "--key", "key", "--value", "value"])
             .assert()
             .success();
     }
 
     async fn momento_cache_get_default_profile() {
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "get", "--key", "key"])
+        cmd.args(["cache", "get", "--key", "key"])
             .assert()
             .stdout("value\n");
     }
@@ -29,7 +29,7 @@ mod tests {
     async fn momento_cache_delete_default_profile() {
         let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "delete", "--name", &test_cache_default])
+        cmd.args(["cache", "delete", "--name", &test_cache_default])
             .assert()
             .success();
     }

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -8,7 +8,7 @@ mod tests {
         let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").unwrap();
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&[
+        cmd.args([
             "cache",
             "create",
             "--name",
@@ -23,7 +23,7 @@ mod tests {
     async fn momento_cache_set_with_profile() {
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&[
+        cmd.args([
             "cache",
             "set",
             "--key",
@@ -40,7 +40,7 @@ mod tests {
     async fn momento_cache_get_with_profile() {
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "get", "--key", "key", "--profile", &test_profile])
+        cmd.args(["cache", "get", "--key", "key", "--profile", &test_profile])
             .assert()
             .stdout("value\n");
     }
@@ -50,7 +50,7 @@ mod tests {
         test_cache_with_profile.push('\n');
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "list", "--profile", &test_profile])
+        cmd.args(["cache", "list", "--profile", &test_profile])
             .assert()
             .stdout(test_cache_with_profile);
     }
@@ -59,7 +59,7 @@ mod tests {
         let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").unwrap();
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&[
+        cmd.args([
             "cache",
             "delete",
             "--name",

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -8,7 +8,7 @@ mod tests {
         let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         let output = Command::cargo_bin("momento")
             .unwrap()
-            .args(&["cache", "list"])
+            .args(["cache", "list"])
             .output()
             .unwrap()
             .stdout;
@@ -19,27 +19,27 @@ mod tests {
                 if !cache.is_empty() {
                     Command::cargo_bin("momento")
                         .unwrap()
-                        .args(&["cache", "delete", "--name", cache])
+                        .args(["cache", "delete", "--name", cache])
                         .unwrap();
                 }
             }
         }
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "create", "--name", &test_cache_default])
+        cmd.args(["cache", "create", "--name", &test_cache_default])
             .assert()
             .success();
     }
 
     async fn momento_cache_set_default_profile() {
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "set", "--key", "key", "--value", "value"])
+        cmd.args(["cache", "set", "--key", "key", "--value", "value"])
             .assert()
             .success();
     }
 
     async fn momento_cache_get_default_profile() {
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "get", "--key", "key"])
+        cmd.args(["cache", "get", "--key", "key"])
             .assert()
             .stdout("value\n");
     }
@@ -48,7 +48,7 @@ mod tests {
         let mut test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         test_cache_default.push('\n');
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "list"])
+        cmd.args(["cache", "list"])
             .assert()
             .stdout(test_cache_default);
     }
@@ -56,7 +56,7 @@ mod tests {
     async fn momento_cache_delete_default_profile() {
         let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(&["cache", "delete", "--name", &test_cache_default])
+        cmd.args(["cache", "delete", "--name", &test_cache_default])
             .assert()
             .success();
     }


### PR DESCRIPTION
Ran the latest momento-cli on an Amazon Linux EC2 instance, and the version was not the oldest `0.11.9` as described in [this ticket](https://github.com/momentohq/momento-cli/issues/181), but it was off by one minor version (supposed to be `0.22.6` but it was `0.22.5`).
I believe this is happening because the cli is built and released before the cargo version is updated and pushed to `release` branch so when the cli is build and released on the publishing assets jobs, it's still referencing the previous version listed in `cargo.toml`.
I added `update-cargo` as one of the needed jobs for both publishing jobs, so hoping that would fix the above issue.

Once this is merged and run the manual release and verify its version on the Linux machine, I will close the ticket: https://github.com/momentohq/momento-cli/issues/181