### PR TITLE
fix: add a step to update cargo version in publish-linux-assets job

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -134,6 +134,12 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
+          
+      - name: Update Cargo Version
+        run: |
+          chmod +x set_cargo_version.sh
+          ./set_cargo_version.sh ${{ steps.semrel.outputs.version }}
+        shell: bash
 
       - name: Build tar.gz and publish asset
         run: |


### PR DESCRIPTION
Even though Cargo version is updated in the `update-cargo` job, the change will only apply to the `release` branch after this workflow is done running.
So we might need to add a step to update Cargo version in the `publish-linux-assets`  job as well to display the correct version.