### PR TITLE
chore: set max TLS version to 1.2

### DIFF
--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -1,7 +1,7 @@
+use reqwest::tls::Version;
 use reqwest::ClientBuilder;
 use serde::{Deserialize, Serialize};
 use std::env;
-use reqwest::tls::Version;
 
 use crate::{error::CliError, utils::console::console_info};
 
@@ -41,23 +41,24 @@ pub async fn signup_user(email: String, cloud: String, region: String) -> Result
         region,
     };
     console_info!("Signing up for Momento...");
-    match ClientBuilder::new().max_tls_version(Version::TLS_1_2).build() {
-        Ok(client) => {
-            match client.post(url).json(body).send().await {
-                Ok(resp) => {
-                    if resp.status().is_success() {
-                        console_info!("Success! Your access token will be emailed to you shortly.")
-                    } else {
-                        let response_json: CreateTokenResponse = resp.json().await.unwrap_or_default();
-                        return Err(CliError {
-                            msg: format!("Failed to create Momento token: {}", response_json.message),
-                        });
-                    }
+    match ClientBuilder::new()
+        .max_tls_version(Version::TLS_1_2)
+        .build()
+    {
+        Ok(client) => match client.post(url).json(body).send().await {
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    console_info!("Success! Your access token will be emailed to you shortly.")
+                } else {
+                    let response_json: CreateTokenResponse = resp.json().await.unwrap_or_default();
+                    return Err(CliError {
+                        msg: format!("Failed to create Momento token: {}", response_json.message),
+                    });
                 }
-                Err(e) => return Err(CliError { msg: e.to_string() }),
             }
-        }
             Err(e) => return Err(CliError { msg: e.to_string() }),
+        },
+        Err(e) => return Err(CliError { msg: e.to_string() }),
     };
     Ok(())
 }

--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -42,6 +42,8 @@ pub async fn signup_user(email: String, cloud: String, region: String) -> Result
     };
     console_info!("Signing up for Momento...");
     match ClientBuilder::new()
+        // We're enforcing TLS1.2 since API Gateway currently does not support TLS1.3 for regional endpoints.
+        // https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html#apigateway-custom-domain-tls-version-edge-optimized
         .max_tls_version(Version::TLS_1_2)
         .build()
     {

--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -41,7 +41,7 @@ pub async fn signup_user(email: String, cloud: String, region: String) -> Result
         region,
     };
     console_info!("Signing up for Momento...");
-    match ClientBuilder::new().max_tls_version(Version::TLS_1_3).build() {
+    match ClientBuilder::new().max_tls_version(Version::TLS_1_2).build() {
         Ok(client) => {
             match client.post(url).json(body).send().await {
                 Ok(resp) => {

--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -1,6 +1,7 @@
-use reqwest::Client;
+use reqwest::ClientBuilder;
 use serde::{Deserialize, Serialize};
 use std::env;
+use reqwest::tls::Version;
 
 use crate::{error::CliError, utils::console::console_info};
 
@@ -40,19 +41,23 @@ pub async fn signup_user(email: String, cloud: String, region: String) -> Result
         region,
     };
     console_info!("Signing up for Momento...");
-    match Client::new().post(url).json(body).send().await {
-        Ok(resp) => {
-            if resp.status().is_success() {
-                console_info!("Success! Your access token will be emailed to you shortly.")
-            } else {
-                let response_json: CreateTokenResponse = resp.json().await.unwrap_or_default();
-                return Err(CliError {
-                    msg: format!("Failed to create Momento token: {}", response_json.message),
-                });
+    match ClientBuilder::new().max_tls_version(Version::TLS_1_3).build() {
+        Ok(client) => {
+            match client.post(url).json(body).send().await {
+                Ok(resp) => {
+                    if resp.status().is_success() {
+                        console_info!("Success! Your access token will be emailed to you shortly.")
+                    } else {
+                        let response_json: CreateTokenResponse = resp.json().await.unwrap_or_default();
+                        return Err(CliError {
+                            msg: format!("Failed to create Momento token: {}", response_json.message),
+                        });
+                    }
+                }
+                Err(e) => return Err(CliError { msg: e.to_string() }),
             }
         }
-        Err(e) => return Err(CliError { msg: e.to_string() }),
+            Err(e) => return Err(CliError { msg: e.to_string() }),
     };
-
     Ok(())
 }

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -3,7 +3,6 @@ mod tests {
 
     use assert_cmd::Command;
     use predicates::prelude::*;
-    use std::str;
 
     async fn momento_cache_create_with_profile() {
         let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").unwrap();
@@ -51,15 +50,9 @@ mod tests {
         test_cache_with_profile.push('\n');
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        let output = cmd
-            .args(["cache", "list", "--profile", &test_profile])
-            .output()
-            .unwrap()
-            .stdout;
-        let string_output = str::from_utf8(&output).unwrap();
-        assert!(string_output
-            .split('\n')
-            .any(|x| x == test_cache_with_profile));
+        cmd.args(["cache", "list", "--profile", &test_profile])
+            .assert()
+            .stdout(test_cache_with_profile);
     }
 
     async fn momento_cache_delete_with_profile() {

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -57,8 +57,7 @@ mod tests {
             .unwrap()
             .stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        let v: Vec<&str> = string_output.split('\n').collect();
-        if !v.contains(&&*test_cache_with_profile) {
+        if !string_output.split('\n').any(|x| x == &*test_cache_with_profile) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -59,7 +59,7 @@ mod tests {
         let string_output = str::from_utf8(&output).unwrap();
         assert!(string_output
             .split('\n')
-            .any(|x| x == &*test_cache_with_profile));
+            .any(|x| x == test_cache_with_profile));
     }
 
     async fn momento_cache_delete_with_profile() {

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -57,13 +57,9 @@ mod tests {
             .unwrap()
             .stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        if !string_output
+        assert!(string_output
             .split('\n')
-            .any(|x| x == &*test_cache_with_profile)
-        {
-            // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
-            cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
-        }
+            .any(|x| x == &*test_cache_with_profile));
     }
 
     async fn momento_cache_delete_with_profile() {

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -57,7 +57,10 @@ mod tests {
             .unwrap()
             .stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        if !string_output.split('\n').any(|x| x == &*test_cache_with_profile) {
+        if !string_output
+            .split('\n')
+            .any(|x| x == &*test_cache_with_profile)
+        {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -50,9 +50,14 @@ mod tests {
         test_cache_with_profile.push('\n');
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(["cache", "list", "--profile", &test_profile])
-            .assert()
-            .stdout(test_cache_with_profile);
+        let output = cmd.args(["cache", "list"])
+            .output()
+            .unwrap()
+            .stdout;;
+        if !output.contains_str(test_cache_default) {
+            // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
+            cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
+        }
     }
 
     async fn momento_cache_delete_with_profile() {

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -50,10 +50,7 @@ mod tests {
         test_cache_with_profile.push('\n');
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        let output = cmd.args(["cache", "list"])
-            .output()
-            .unwrap()
-            .stdout;;
+        let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         if !output.contains_str(test_cache_default) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -3,6 +3,7 @@ mod tests {
 
     use assert_cmd::Command;
     use predicates::prelude::*;
+    use std::str;
 
     async fn momento_cache_create_with_profile() {
         let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").unwrap();
@@ -50,8 +51,14 @@ mod tests {
         test_cache_with_profile.push('\n');
         let test_profile = std::env::var("TEST_PROFILE").unwrap();
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
-        if !output.contains_str(test_cache_default) {
+        let output = cmd
+            .args(["cache", "list", "--profile", &test_profile])
+            .output()
+            .unwrap()
+            .stdout;
+        let string_output = str::from_utf8(&output).unwrap();
+        let v: Vec<&str> = string_output.split('\n').collect();
+        if !v.contains(&&*test_cache_with_profile) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -47,9 +47,9 @@ mod tests {
         let mut test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         test_cache_default.push('\n');
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
-        let string_output = str::from_utf8(&output).unwrap();
-        assert!(string_output.split('\n').any(|x| x == test_cache_default));
+        cmd.args(["cache", "list"])
+            .assert()
+            .stdout(test_cache_default);
     }
 
     async fn momento_cache_delete_default_profile() {

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -3,6 +3,7 @@ mod tests {
 
     use assert_cmd::Command;
     use std::str;
+    use predicates::prelude::predicate;
 
     async fn momento_cache_create_default_profile() {
         let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
@@ -48,9 +49,14 @@ mod tests {
         let mut test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         test_cache_default.push('\n');
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(["cache", "list"])
-            .assert()
-            .stdout(test_cache_default);
+        let output = cmd.args(["cache", "list"])
+            .output()
+            .unwrap()
+            .stdout;;
+        if !output.contains_str(test_cache_default) {
+            // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
+            cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
+        }
     }
 
     async fn momento_cache_delete_default_profile() {

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -50,9 +50,7 @@ mod tests {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        assert!(string_output
-            .split('\n')
-            .any(|x| x == &*test_cache_default));
+        assert!(string_output.split('\n').any(|x| x == &*test_cache_default));
     }
 
     async fn momento_cache_delete_default_profile() {

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -50,8 +50,7 @@ mod tests {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        let v: Vec<&str> = string_output.split('\n').collect();
-        if !v.contains(&&*test_cache_default) {
+        if !string_output.split('\n').any(|x| x == &*test_cache_with_profile) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -50,10 +50,9 @@ mod tests {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        if !string_output.split('\n').any(|x| x == &*test_cache_default) {
-            // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
-            cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
-        }
+        assert!(string_output
+            .split('\n')
+            .any(|x| x == &*test_cache_default));
     }
 
     async fn momento_cache_delete_default_profile() {

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -50,10 +50,7 @@ mod tests {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        if !string_output
-            .split('\n')
-            .any(|x| x == &*test_cache_with_profile)
-        {
+        if !string_output.split('\n').any(|x| x == &*test_cache_default) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
-
     use assert_cmd::Command;
     use predicates::prelude::predicate;
     use std::str;
@@ -50,7 +49,9 @@ mod tests {
         test_cache_default.push('\n');
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
-        if !output.contains_str(test_cache_default) {
+        let string_output = str::from_utf8(&output).unwrap();
+        let v: Vec<&str> = string_output.split('\n').collect();
+        if !v.contains(&&*test_cache_default) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -50,7 +50,10 @@ mod tests {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        if !string_output.split('\n').any(|x| x == &*test_cache_with_profile) {
+        if !string_output
+            .split('\n')
+            .any(|x| x == &*test_cache_with_profile)
+        {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));
         }

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod tests {
     use assert_cmd::Command;
-    use predicates::prelude::predicate;
     use std::str;
 
     async fn momento_cache_create_default_profile() {
@@ -50,7 +49,7 @@ mod tests {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         let string_output = str::from_utf8(&output).unwrap();
-        assert!(string_output.split('\n').any(|x| x == &*test_cache_default));
+        assert!(string_output.split('\n').any(|x| x == test_cache_default));
     }
 
     async fn momento_cache_delete_default_profile() {

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -2,8 +2,8 @@
 mod tests {
 
     use assert_cmd::Command;
-    use std::str;
     use predicates::prelude::predicate;
+    use std::str;
 
     async fn momento_cache_create_default_profile() {
         let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
@@ -49,10 +49,7 @@ mod tests {
         let mut test_cache_default = std::env::var("TEST_CACHE_DEFAULT").unwrap();
         test_cache_default.push('\n');
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        let output = cmd.args(["cache", "list"])
-            .output()
-            .unwrap()
-            .stdout;;
+        let output = cmd.args(["cache", "list"]).output().unwrap().stdout;
         if !output.contains_str(test_cache_default) {
             // Exit status 3 indicates cache list operation didn't include test_cache_default in the returned list.
             cmd.args(["cache", "list"]).assert().code(predicate::ne(3));


### PR DESCRIPTION
When I forced to use TLS version 1.3 (set minimum TLS version to 1.3) on both Mac and Windows, I received the below error:


**Mac OS**
```
./target/debug/momento account --verbose signup aws --email eem@momentohq.com --region us-west-2
Signing up for Momento...
[2022-12-06T18:05:40Z DEBUG reqwest::connect] starting new connection: https://signup.registry.prod.a.momentohq.com/
[2022-12-06T18:05:40Z DEBUG hyper::client::connect::dns] resolving host="signup.registry.prod.a.momentohq.com"
[2022-12-06T18:05:40Z DEBUG hyper::client::connect::http] connecting to 44.237.124.50:443
[2022-12-06T18:05:40Z DEBUG hyper::client::connect::http] connected to 44.237.124.50:443
[2022-12-06T18:05:40Z DEBUG rustls::client::hs] No cached session for DnsName(DnsName(DnsName("signup.registry.prod.a.momentohq.com")))
[2022-12-06T18:05:40Z DEBUG rustls::client::hs] Not resuming any session
[2022-12-06T18:05:40Z WARN  rustls::conn] Sending fatal alert ProtocolVersion
ERROR: error sending request for url (https://signup.registry.prod.a.momentohq.com/token/create): error trying to connect: peer is incompatible: server's TLS version is disabled in client
```

**Windows**
```
momento.exe account --verbose signup aws --email eem@momentohq.com --region us-west-2
Signing up for Momento...
[2022-12-07T00:06:18Z DEBUG reqwest::connect] starting new connection: https://signup.registry.prod.a.momentohq.com/
[2022-12-07T00:06:18Z DEBUG hyper::client::connect::dns] resolving host="signup.registry.prod.a.momentohq.com"
[2022-12-07T00:06:18Z DEBUG hyper::client::connect::http] connecting to 35.165.103.40:443
[2022-12-07T00:06:18Z DEBUG hyper::client::connect::http] connected to 35.165.103.40:443
[2022-12-07T00:06:18Z DEBUG rustls::client::hs] No cached session for DnsName(DnsName(DnsName("signup.registry.prod.a.momentohq.com")))
[2022-12-07T00:06:18Z DEBUG rustls::client::hs] Not resuming any session
[2022-12-07T00:06:18Z WARN  rustls::conn] Sending fatal alert ProtocolVersion
ERROR: error sending request for url (https://signup.registry.prod.a.momentohq.com/token/create): error trying to connect: peer is incompatible: server's TLS version is disabled in client
```

By setting max TLS version for a rustls client to 1.2, it should always use TLS 1.2 to or less for connections.
For both Mac OS and Windows, no error has been observed and it uses TLS 1.2:


**Mac OS**
```
./target/debug/momento account --verbose signup aws --email eem@momentohq.com --region us-west-2
Signing up for Momento...
[2022-12-06T18:09:03Z DEBUG reqwest::connect] starting new connection: https://signup.registry.prod.a.momentohq.com/
[2022-12-06T18:09:03Z DEBUG hyper::client::connect::dns] resolving host="signup.registry.prod.a.momentohq.com"
[2022-12-06T18:09:03Z DEBUG hyper::client::connect::http] connecting to 35.165.103.40:443
[2022-12-06T18:09:03Z DEBUG hyper::client::connect::http] connected to 35.165.103.40:443
[2022-12-06T18:09:03Z DEBUG rustls::client::hs] No cached session for DnsName(DnsName(DnsName("signup.registry.prod.a.momentohq.com")))
[2022-12-06T18:09:03Z DEBUG rustls::client::hs] Not resuming any session
[2022-12-06T18:09:03Z DEBUG rustls::client::hs] ALPN protocol is Some(b"h2")
[2022-12-06T18:09:03Z DEBUG rustls::client::hs] Using ciphersuite Tls12(Tls12CipherSuite { suite: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, bulk: Aes128Gcm })
[2022-12-06T18:09:03Z DEBUG rustls::client::tls12] ECDHE curve is ECParameters { curve_type: NamedCurve, named_group: secp256r1 }
[2022-12-06T18:09:03Z DEBUG rustls::client::tls12] Server DNS name is DnsName(DnsName(DnsName("signup.registry.prod.a.momentohq.com")))
[2022-12-06T18:09:03Z DEBUG rustls::client::tls12] Session not saved: server didn't allocate id or ticket
[2022-12-06T18:09:03Z DEBUG h2::client] binding client connection
[2022-12-06T18:09:03Z DEBUG h2::client] client connection bound
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_write] send frame=Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384 }
[2022-12-06T18:09:03Z DEBUG h2::proto::connection] Connection; peer=Client
[2022-12-06T18:09:03Z DEBUG hyper::client::pool] pooling idle connection for ("https", signup.registry.prod.a.momentohq.com)
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_read] received frame=Settings { flags: (0x0), max_concurrent_streams: 128, initial_window_size: 65536, max_frame_size: 16777215 }
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_write] send frame=Settings { flags: (0x1: ACK) }
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_read] received frame=WindowUpdate { stream_id: StreamId(0), size_increment: 2147418112 }
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_write] send frame=WindowUpdate { stream_id: StreamId(0), size_increment: 5177345 }
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_write] send frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[2022-12-06T18:09:03Z DEBUG h2::codec::framed_write] send frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
[2022-12-06T18:09:04Z DEBUG h2::codec::framed_read] received frame=Settings { flags: (0x1: ACK) }
[2022-12-06T18:09:04Z DEBUG h2::proto::settings] received settings ACK; applying Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384 }
[2022-12-06T18:09:14Z DEBUG h2::codec::framed_read] received frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[2022-12-06T18:09:14Z DEBUG h2::codec::framed_read] received frame=Data { stream_id: StreamId(1) }
[2022-12-06T18:09:14Z DEBUG h2::codec::framed_read] received frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
[2022-12-06T18:09:14Z DEBUG reqwest::async_impl::client] response '201 Created' for https://signup.registry.prod.a.momentohq.com/token/create
Success! Your access token will be emailed to you shortly.
[2022-12-06T18:09:14Z DEBUG h2::codec::framed_write] send frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }
[2022-12-06T18:09:14Z DEBUG h2::proto::connection] Connection::poll; connection error error=GoAway(b"", NO_ERROR, Library)
[2022-12-06T18:09:14Z DEBUG rustls::conn] Sending warning alert CloseNotify
```

**Windows**
```
 momento.exe account --verbose signup aws --email eem@momentohq.com --region us-west-2
Signing up for Momento...
[2022-12-07T00:07:18Z DEBUG reqwest::connect] starting new connection: https://signup.registry.prod.a.momentohq.com/
[2022-12-07T00:07:18Z DEBUG hyper::client::connect::dns] resolving host="signup.registry.prod.a.momentohq.com"
[2022-12-07T00:07:18Z DEBUG hyper::client::connect::http] connecting to 35.165.103.40:443
[2022-12-07T00:07:18Z DEBUG hyper::client::connect::http] connected to 35.165.103.40:443
[2022-12-07T00:07:18Z DEBUG rustls::client::hs] No cached session for DnsName(DnsName(DnsName("signup.registry.prod.a.momentohq.com")))
[2022-12-07T00:07:18Z DEBUG rustls::client::hs] Not resuming any session
[2022-12-07T00:07:18Z DEBUG rustls::client::hs] ALPN protocol is Some(b"h2")
[2022-12-07T00:07:18Z DEBUG rustls::client::hs] Using ciphersuite Tls12(Tls12CipherSuite { suite: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, bulk: Aes128Gcm })
[2022-12-07T00:07:18Z DEBUG rustls::client::tls12] ECDHE curve is ECParameters { curve_type: NamedCurve, named_group: secp256r1 }
[2022-12-07T00:07:18Z DEBUG rustls::client::tls12] Server DNS name is DnsName(DnsName(DnsName("signup.registry.prod.a.momentohq.com")))
[2022-12-07T00:07:18Z DEBUG rustls::client::tls12] Session not saved: server didn't allocate id or ticket
[2022-12-07T00:07:18Z DEBUG h2::client] binding client connection
[2022-12-07T00:07:18Z DEBUG h2::client] client connection bound
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_write] send frame=Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384 }
[2022-12-07T00:07:18Z DEBUG h2::proto::connection] Connection; peer=Client
[2022-12-07T00:07:18Z DEBUG hyper::client::pool] pooling idle connection for ("https", signup.registry.prod.a.momentohq.com)
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_read] received frame=Settings { flags: (0x0), max_concurrent_streams: 128, initial_window_size: 65536, max_frame_size: 16777215 }
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_write] send frame=Settings { flags: (0x1: ACK) }
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_read] received frame=WindowUpdate { stream_id: StreamId(0), size_increment: 2147418112 }
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_write] send frame=WindowUpdate { stream_id: StreamId(0), size_increment: 5177345 }
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_write] send frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_write] send frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
[2022-12-07T00:07:18Z DEBUG h2::codec::framed_read] received frame=Settings { flags: (0x1: ACK) }
[2022-12-07T00:07:18Z DEBUG h2::proto::settings] received settings ACK; applying Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384 }
[2022-12-07T00:07:23Z DEBUG h2::codec::framed_read] received frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[2022-12-07T00:07:23Z DEBUG h2::codec::framed_read] received frame=Data { stream_id: StreamId(1) }
[2022-12-07T00:07:23Z DEBUG h2::codec::framed_read] received frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
[2022-12-07T00:07:23Z DEBUG reqwest::async_impl::client] response '201 Created' for https://signup.registry.prod.a.momentohq.com/token/create
Success! Your access token will be emailed to you shortly.
[2022-12-07T00:07:23Z DEBUG h2::codec::framed_write] send frame=GoAway { error_code: NO_ERROR, last_stream_id: StreamId(0) }
[2022-12-07T00:07:23Z DEBUG h2::proto::connection] Connection::poll; connection error error=GoAway(b"", NO_ERROR, Library)
[2022-12-07T00:07:23Z DEBUG rustls::conn] Sending warning alert CloseNotify
```

@cprice404 
I think we want to ask whoever has access to Windows to try it out to verify no error occurs with this change once it's merged.

I also updated the tests for cache list operation so that it won't be impacted by other existing caches.

Closes #165 