### PR TITLE
fix: reference proper version number

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -169,6 +169,12 @@ jobs:
           components: rustfmt
           override: true
 
+      - name: Update Cargo Version
+        run: |
+          chmod +x set_cargo_version.sh
+          ./set_cargo_version.sh ${{ needs.release.outputs.version }}
+        shell: bash
+
       - name: Build zip for windows_x86_64 and create release
         id: create_release
         run: |

--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -134,11 +134,11 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
-          
+
       - name: Update Cargo Version
         run: |
           chmod +x set_cargo_version.sh
-          ./set_cargo_version.sh ${{ steps.semrel.outputs.version }}
+          ./set_cargo_version.sh ${{ needs.release.outputs.version }}
         shell: bash
 
       - name: Build tar.gz and publish asset


### PR DESCRIPTION
Fixed the incorrect version number reference that was used to update cargo version in the `publish-linux-asset` job.
Also, added a step to update cargo version in the `publish-windows-asset` job.
