### PR TITLE
feat: move signing key command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,11 @@ enum Subcommand {
         #[structopt(subcommand)]
         operation: AccountCommand,
     },
+    #[structopt(about = "Manage signing keys")]
+    SigningKey {
+        #[structopt(subcommand)]
+        operation: SigningKeyCommand,
+    },
     #[cfg(feature = "login")]
     #[structopt(
         about = "*Construction Zone* We're working on this! *Construction Zone* Log in to manage your Momento account"
@@ -65,15 +70,9 @@ enum Subcommand {
 }
 
 #[derive(Debug, StructOpt)]
-enum AccountCommand {
-    #[structopt(about = "Sign up for Momento")]
-    Signup {
-        #[structopt(subcommand)]
-        signup_operation: CloudSignupCommand,
-    },
-
+enum SigningKeyCommand {
     #[structopt(about = "Create a signing key")]
-    CreateSigningKey {
+    Create {
         #[structopt(
             long = "ttl",
             short = 't',
@@ -87,7 +86,7 @@ enum AccountCommand {
     },
 
     #[structopt(about = "Revoke the signing key")]
-    RevokeSigningKey {
+    Revoke {
         #[structopt(long = "key-id", short, help = "Signing Key ID")]
         key_id: String,
 
@@ -96,9 +95,18 @@ enum AccountCommand {
     },
 
     #[structopt(about = "List all signing keys")]
-    ListSigningKeys {
+    List {
         #[structopt(long = "endpoint", short = 'e')]
         endpoint: Option<String>,
+    },
+}
+
+#[derive(Debug, StructOpt)]
+enum AccountCommand {
+    #[structopt(about = "Sign up for Momento")]
+    Signup {
+        #[structopt(subcommand)]
+        signup_operation: CloudSignupCommand,
     },
 }
 
@@ -267,7 +275,9 @@ async fn entrypoint() -> Result<(), CliError> {
                     commands::account::signup_user(email, "aws".to_string(), region).await?
                 }
             },
-            AccountCommand::CreateSigningKey {
+        },
+        Subcommand::SigningKey {operation} => match operation {
+            SigningKeyCommand::Create {
                 ttl_minutes,
                 endpoint,
             } => {
@@ -279,7 +289,7 @@ async fn entrypoint() -> Result<(), CliError> {
                 )
                 .await?;
             }
-            AccountCommand::RevokeSigningKey { key_id, endpoint } => {
+            SigningKeyCommand::Revoke { key_id, endpoint } => {
                 let (creds, _config) = get_creds_and_config(&args.profile).await?;
                 commands::signingkey::signingkey_cli::revoke_signing_key(
                     key_id.clone(),
@@ -289,7 +299,7 @@ async fn entrypoint() -> Result<(), CliError> {
                 .await?;
                 debug!("revoked signing key {}", key_id)
             }
-            AccountCommand::ListSigningKeys { endpoint } => {
+            SigningKeyCommand::List { endpoint } => {
                 let (creds, _config) = get_creds_and_config(&args.profile).await?;
                 commands::signingkey::signingkey_cli::list_signing_keys(creds.token, endpoint)
                     .await?

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -83,10 +83,14 @@ mod tests {
             // configure subcommand
             vec!["configure", "--profile", &test_profile],
             vec!["--profile", &test_profile, "configure"],
+            // signing-key subcommand
+            vec!["signing-key", "list", "--profile", &test_profile],
+            vec!["signing-key", "--profile", &test_profile, "list"],
+            vec!["--profile", &test_profile, "signing-key", "list"],
             // account subcommand
-            vec!["account", "list-signing-keys", "--profile", &test_profile],
-            vec!["account", "--profile", &test_profile, "list-signing-keys"],
-            vec!["--profile", &test_profile, "account", "list-signing-keys"],
+            vec!["account", "signup", "--profile", &test_profile, "help"],
+            vec!["account", "--profile", &test_profile, "signup", "help"],
+            vec!["--profile", &test_profile, "account", "signup", "help"],
         ];
         for command_line_args in profile_permutations {
             let mut cmd = Command::cargo_bin("momento").unwrap();


### PR DESCRIPTION
This commit moves the `signing-key` subcommands out of the `account` subcommand and into their own top-level subcommands:

- momento signing-key create
- momento signing-key list
- momento signing-key revoke
