### PR TITLE
fix:`on-push-to-release` workflow

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -136,8 +136,6 @@ jobs:
     strategy:
       matrix:
         architecture: [ x86_64 ]
-    container:
-      image: quay.io/pypa/manylinux2014_${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -197,9 +195,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
+        run: yum install python3-devel python3-pip -y
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable


### PR DESCRIPTION
I found out that the container used for the `publish-linux-asset` job, `quay.io/pypa/manylinux2014_x86_64`, does not work well with `actions/setup-python@v2`.
Therefore, I removed that action and installed python3 and pip3 with yum.
Tested locally with the exact same image, `quay.io/pypa/manylinux2014_x86_64`, and I was able to run `set_cargo_version.sh` successfully.
I also removed the container from the `publish-rpm-package` job to remove any complexity since we don't need to use a container to run this job.

This PR should make the `on-push-to-release` workflow run successfully and update the momento-cli version; therefore,
1. linux asset will be successfully released
2. correct momento-cli version will be displayed on linux
3. rpm package (x86_64) will be released 
🤞 

@cprice404 @virratanasangpunth 
cc/ @rlinehan @ksmotiv8 