### PR TITLE
fix: use correct version reference

### DIFF
--- a/.github/workflows/on-push-to-release.yml
+++ b/.github/workflows/on-push-to-release.yml
@@ -168,7 +168,7 @@ jobs:
           package: ${{ env.APP_NAME }}
           package_root: .rpmpkg
           maintainer: ${{ env.MAINTAINER }}
-          version: ${{ steps.semrel.outputs.version }}
+          version: ${{ needs.release.outputs.version }}
           arch: ${{ matrix.architecture }}
           desc: ${{ env.DESC }}
 


### PR DESCRIPTION
The `publish-rpm-package` job was failed because the wrong version reference was passed and an empty version was passed to create a rpm package.
https://github.com/momentohq/momento-cli/actions/runs/3659355567/jobs/6185405904#step:8:22
Use a correct reference to the release version.
