### PR TITLE
chore: put momento binary at root of archive files

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           VERSION=${{ needs.release.outputs.version }}
           BINARY_FILE="momento-cli-$VERSION.linux_${{ matrix.architecture.rpm-arch-shortname }}.tar.gz"
-          tar zcvf $BINARY_FILE ./target/${{ matrix.architecture.target }}/release/momento
+          tar -C ./target/${{ matrix.architecture.target }}/release/ -zcvf $BINARY_FILE momento
           AUTH="Authorization: token ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}"
           LATEST_RELEASE=$(curl -sH "$AUTH" https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION})
           RELEASE_ID=$(echo $LATEST_RELEASE | jq -r .id)

--- a/tests/configure_profiles_test.rs
+++ b/tests/configure_profiles_test.rs
@@ -4,7 +4,8 @@ mod tests {
     use assert_cmd::Command;
 
     async fn configure_momento_default_profile() {
-        let test_auth_token = std::env::var("TEST_AUTH_TOKEN_DEFAULT").expect("Missing required env var TEST_AUTH_TOKEN_DEFAULT");
+        let test_auth_token = std::env::var("TEST_AUTH_TOKEN_DEFAULT")
+            .expect("Missing required env var TEST_AUTH_TOKEN_DEFAULT");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["configure"])
             .write_stdin(test_auth_token)
@@ -27,7 +28,8 @@ mod tests {
     }
 
     async fn momento_cache_delete_default_profile() {
-        let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").expect("Missing required env var TEST_CACHE_DEFAULT");
+        let test_cache_default = std::env::var("TEST_CACHE_DEFAULT")
+            .expect("Missing required env var TEST_CACHE_DEFAULT");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["cache", "delete", "--name", &test_cache_default])
             .assert()

--- a/tests/momento_additional_profile.rs
+++ b/tests/momento_additional_profile.rs
@@ -5,8 +5,10 @@ mod tests {
     use predicates::prelude::*;
 
     async fn momento_cache_create_with_profile() {
-        let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").expect("Missing required env var TEST_CACHE_WITH_PROFILE");
-        let test_profile = std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
+        let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE")
+            .expect("Missing required env var TEST_CACHE_WITH_PROFILE");
+        let test_profile =
+            std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args([
             "cache",
@@ -21,7 +23,8 @@ mod tests {
     }
 
     async fn momento_cache_set_with_profile() {
-        let test_profile = std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
+        let test_profile =
+            std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args([
             "cache",
@@ -38,7 +41,8 @@ mod tests {
     }
 
     async fn momento_cache_get_with_profile() {
-        let test_profile = std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
+        let test_profile =
+            std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["cache", "get", "--key", "key", "--profile", &test_profile])
             .assert()
@@ -46,9 +50,11 @@ mod tests {
     }
 
     async fn momento_cache_list_with_profile() {
-        let mut test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").expect("Missing required env var TEST_CACHE_WITH_PROFILE");
+        let mut test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE")
+            .expect("Missing required env var TEST_CACHE_WITH_PROFILE");
         test_cache_with_profile.push('\n');
-        let test_profile = std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
+        let test_profile =
+            std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["cache", "list", "--profile", &test_profile])
             .assert()
@@ -56,8 +62,10 @@ mod tests {
     }
 
     async fn momento_cache_delete_with_profile() {
-        let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE").expect("Missing required env var TEST_CACHE_WITH_PROFILE");
-        let test_profile = std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
+        let test_cache_with_profile = std::env::var("TEST_CACHE_WITH_PROFILE")
+            .expect("Missing required env var TEST_CACHE_WITH_PROFILE");
+        let test_profile =
+            std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args([
             "cache",
@@ -72,7 +80,8 @@ mod tests {
     }
 
     async fn test_profile_allowed_in_any_position() {
-        let test_profile = std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
+        let test_profile =
+            std::env::var("TEST_PROFILE").expect("Missing required env var TEST_PROFILE");
 
         let profile_permutations = vec![
             // cache subcommand

--- a/tests/momento_default_profile.rs
+++ b/tests/momento_default_profile.rs
@@ -4,7 +4,8 @@ mod tests {
     use std::str;
 
     async fn momento_cache_create_default_profile() {
-        let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").expect("Missing required env var TEST_CACHE_DEFAULT");
+        let test_cache_default = std::env::var("TEST_CACHE_DEFAULT")
+            .expect("Missing required env var TEST_CACHE_DEFAULT");
         let output = Command::cargo_bin("momento")
             .unwrap()
             .args(["cache", "list"])
@@ -44,7 +45,8 @@ mod tests {
     }
 
     async fn momento_cache_list_default_profile() {
-        let mut test_cache_default = std::env::var("TEST_CACHE_DEFAULT").expect("Missing required env var TEST_CACHE_DEFAULT");
+        let mut test_cache_default = std::env::var("TEST_CACHE_DEFAULT")
+            .expect("Missing required env var TEST_CACHE_DEFAULT");
         test_cache_default.push('\n');
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["cache", "list"])
@@ -53,7 +55,8 @@ mod tests {
     }
 
     async fn momento_cache_delete_default_profile() {
-        let test_cache_default = std::env::var("TEST_CACHE_DEFAULT").expect("Missing required env var TEST_CACHE_DEFAULT");
+        let test_cache_default = std::env::var("TEST_CACHE_DEFAULT")
+            .expect("Missing required env var TEST_CACHE_DEFAULT");
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["cache", "delete", "--name", &test_cache_default])
             .assert()


### PR DESCRIPTION
This commit changes the code that produces the archive files
so that the momento binary will be at the root.  It seems as
though homebrew formulae won't work properly for linux if the
binary is at a nested path.
