### PR TITLE
chore: sign windows installer

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -293,7 +293,7 @@ jobs:
           DISTRIBUTABLE_FILE_PREFIX: ${{ steps.build.outputs.distributable_file_prefix }}
         run: |
           $zipFilename = "$env:DISTRIBUTABLE_FILE_PREFIX.zip"
-          $zipPath = Get-Location + "\" + $zipFilename
+          $zipPath = ".\$zipFilename"
           Compress-Archive -LiteralPath $env:MOMENTO_BINARY_PATH -DestinationPath $zipPath
 
           echo "::set-output name=asset_path::$zipPath"
@@ -311,10 +311,11 @@ jobs:
         run: |
           cp $env:MOMENTO_BINARY_PATH .\windows\installer
           # NB: MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
-          $BuildVersion = "$env:VERSION.0"
+          # Also note the build expects this to be an environment variable
+          $env:BuildVersion = "$env:VERSION.0"
           msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$env:DISTRIBUTABLE_FILE_PREFIX
 
-          $msiFilename = "env:DISTRIBUTABLE_FILE_PREFIX.msi"
+          $msiFilename = "$env:DISTRIBUTABLE_FILE_PREFIX.msi"
           $msiPath = ".\windows\installer\bin\Release\$msiFilename"
           echo "::set-output name=asset_path::$msiPath"
           echo "::set-output name=asset_name::$msiFilename"

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -279,7 +279,7 @@ jobs:
           CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
           CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
         run: |
-          $momentoBinaryPath =".\target\x86_64-pc-windows-gnu\release\momento.exe"
+          $momentoBinaryPath = ".\target\x86_64-pc-windows-gnu\release\momento.exe"
           & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $momentoBinaryPath
 
       - name: Create zip and installer packages
@@ -289,17 +289,16 @@ jobs:
           CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
           CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
         run: |
-          cp .\target\x86_64-pc-windows-gnu\release\momento.exe .\windows\installer\
-
+          # Create zipfile
+          $momentoBinaryPath = ".\target\x86_64-pc-windows-gnu\release\momento.exe"
           $version = "${{ needs.release.outputs.version }}"
           $binaryFile64Prefix = "momento-cli-$version.windows_x86_64"
-
-          # Create zipfile
           $binaryFile64Zip = "$binaryFile64Prefix.zip"
           $destinationPathZip = Get-Location + "\" + $binaryFile64Zip
-          Compress-Archive -LiteralPath $MomentoBinaryPath -DestinationPath $destinationPathZip
+          Compress-Archive -LiteralPath $momentoBinaryPath -DestinationPath $destinationPathZip
 
           # Build the installer
+          cp $momentoBinaryPath .\windows\installer
           # NB: MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
           $BuildVersion = "$version.0"
           msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$binaryFile64Prefix

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -296,8 +296,8 @@ jobs:
           $zipPath = Get-Location + "\" + $zipFilename
           Compress-Archive -LiteralPath $env:MOMENTO_BINARY_PATH -DestinationPath $zipPath
 
-          echo "::set-output name=asset_path_zip::$zipPath"
-          echo "::set-output name=asset_name_zip::$zipFilename"
+          echo "::set-output name=asset_path::$zipPath"
+          echo "::set-output name=asset_name::$zipFilename"
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
@@ -316,15 +316,15 @@ jobs:
 
           $msiFilename = "env:DISTRIBUTABLE_FILE_PREFIX.msi"
           $msiPath = ".\windows\installer\bin\Release\$msiFilename"
-          echo "::set-output name=asset_path_msi::$msiPath"
-          echo "::set-output name=asset_name_msi::$msiFilename"
+          echo "::set-output name=asset_path::$msiPath"
+          echo "::set-output name=asset_name::$msiFilename"
           
       - name: Sign installer
         env:
           SIGNTOOL_PATH: ${{ steps.signtool.outputs.signtool_path }}
           CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
           CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
-          MSI_PATH: ${{ steps.build_installer.outputs.asset_path_msi }}
+          MSI_PATH: ${{ steps.build_installer.outputs.asset_path }}
         run: |
           & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:MSI_PATH
 
@@ -336,8 +336,8 @@ jobs:
       - name: Create zip and installer urls
         id: create_release_urls
         env:
-          ZIP_FILENAME: ${{ steps.create_zip.outputs.asset_name_zip }}
-          MSI_FILENAME: ${{ steps.create_zip.outputs.asset_name_msi }}
+          ZIP_FILENAME: ${{ steps.create_zip.outputs.asset_name }}
+          MSI_FILENAME: ${{ steps.build_installer.outputs.asset_name }}
         run: |
           $latestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v${{ needs.release.outputs.version }}"
           $latestRelease = (Invoke-WebRequest -Uri $latestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
@@ -353,8 +353,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_urls.outputs.upload_url_msi }}
-          asset_path: ${{ steps.build_installer.outputs.asset_path_msi }}
-          asset_name: ${{ steps.build_installer.outputs.asset_name_msi }}
+          asset_path: ${{ steps.build_installer.outputs.asset_path }}
+          asset_name: ${{ steps.build_installer.outputs.asset_name }}
           asset_content_type: application/octet-stream
 
       - name: Upload windows_x86_64 zip
@@ -363,8 +363,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release_urls.outputs.upload_url_zip }}
-          asset_path: ${{ steps.create_zip.outputs.asset_path_zip }}
-          asset_name: ${{ steps.create_zip.outputs.asset_name_zip }}
+          asset_path: ${{ steps.create_zip.outputs.asset_path }}
+          asset_name: ${{ steps.create_zip.outputs.asset_name }}
           asset_content_type: application/zip
 
       # Commenting out building i686 since the machine doesn't seem to have i686-w64-mingw32-gcc.exe compiler installed by default.

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -251,9 +251,31 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
 
+      - name: Write PFX certificate file
+        id: write_pfx
+        env:
+          PFX_CONTENT: ${{ secrets.CODE_SIGNING_CERT_BASE64 }}
+        run: |
+          $pfxPath = "cert.pfx";
+          $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
+          Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
+          echo "::set-output name=pfx_path::$pfxPath";
+
+      - name: Test and cache signtool path
+        id: signtool
+        run: |
+          $signtool = "C:/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x86/signtool.exe"
+          Test-Path -Path $signtool -PathType Leaf
+          echo "::set-output name=signtool_path::$signtool"
+
       - name: Build installer for windows_x86_64 and create release
         id: create_release
+        env:
+          SIGNTOOL_PATH: ${{ steps.signtool.signtool_path }}
+          CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
+          CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
         run: |
+          # Build windows Momento binary
           rustup target add x86_64-pc-windows-gnu
           cargo build --release --target x86_64-pc-windows-gnu
 
@@ -262,19 +284,27 @@ jobs:
           $env:Version = "${{ needs.release.outputs.version }}"
           $env:BinaryFile64Prefix = "momento-cli-$env:Version.windows_x86_64"
 
+          # Sign the executable
+          $env:CurrentDir = Get-Location
+          $env:MomentoBinaryPath = $env:CurrentDir + "\target\x86_64-pc-windows-gnu\release\momento.exe"
+          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:MomentoBinaryPath
+
           # Create zipfile
           $env:BinaryFile64Zip = "$env:BinaryFile64Prefix.zip"
-          $env:CurrentDir = Get-Location
-          $env:LiteralPath = $env:CurrentDir + "\target\x86_64-pc-windows-gnu\release\momento.exe"
           $env:DestinationPathZip = $env:CurrentDir + "\" + $env:BinaryFile64Zip
-          Compress-Archive -LiteralPath $env:LiteralPath -DestinationPath $env:DestinationPathZip
+          Compress-Archive -LiteralPath $env:MomentoBinaryPath -DestinationPath $env:DestinationPathZip
 
-          # MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
+          # Build the installer
+          # NB: MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
           $env:BuildVersion = "$env:Version.0"
           msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$env:BinaryFile64Prefix
           $env:BinaryFile64Msi = "$env:BinaryFile64Prefix.msi"
           $env:DestinationPathMsi = ".\windows\installer\bin\Release\$env:BinaryFile64Msi"
 
+          # Sign the installer
+          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:DestinationPathMsi
+
+          # Write asset paths
           $env:LatestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v$env:Version"
           $env:LatestReleaseUri
           $env:LatestRelease = (Invoke-WebRequest -Uri $env:LatestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
@@ -287,7 +317,11 @@ jobs:
           echo "::set-output name=asset_path_zip::$env:DestinationPathZip"
           echo "::set-output name=asset_name_msi::$env:BinaryFile64Msi"
           echo "::set-output name=asset_name_zip::$env:BinaryFile64Zip"
-        shell: pwsh
+
+      - name: Delete PFX certificate
+        env:
+          CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
+        run: Remove-Item -Path $env:CERT_PATH
 
       - name: Upload windows_x86_64 msi
         uses: actions/upload-release-asset@v1
@@ -337,7 +371,6 @@ jobs:
       #     echo "::set-output name=upload_url::$GhAsset32"
       #     echo "::set-output name=asset_path::$env:DestinationPath"
       #     echo "::set-output name=asset_name::$env:BinaryFile32"
-      #   shell: pwsh
 
       # - name: Upload windows_i686 zip
       #   uses: actions/upload-release-asset@v1

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -248,6 +248,11 @@ jobs:
           cat Cargo.toml
         shell: bash
 
+      - name: Build
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          cargo build --release --target x86_64-pc-windows-gnu
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
 
@@ -268,55 +273,55 @@ jobs:
           Test-Path -Path $signtool -PathType Leaf
           echo "::set-output name=signtool_path::$signtool"
 
-      - name: Build installer for windows_x86_64 and create release
+      - name: Sign Momento Binary
+        env:
+          SIGNTOOL_PATH: ${{ steps.signtool.signtool_path }}
+          CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
+          CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+        run: |
+          $momentoBinaryPath =".\target\x86_64-pc-windows-gnu\release\momento.exe"
+          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $momentoBinaryPath
+
+      - name: Create zip and installer packages
         id: create_release
         env:
           SIGNTOOL_PATH: ${{ steps.signtool.signtool_path }}
           CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
           CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
         run: |
-          # Build windows Momento binary
-          rustup target add x86_64-pc-windows-gnu
-          cargo build --release --target x86_64-pc-windows-gnu
-
           cp .\target\x86_64-pc-windows-gnu\release\momento.exe .\windows\installer\
 
-          $env:Version = "${{ needs.release.outputs.version }}"
-          $env:BinaryFile64Prefix = "momento-cli-$env:Version.windows_x86_64"
-
-          # Sign the executable
-          $env:CurrentDir = Get-Location
-          $env:MomentoBinaryPath = $env:CurrentDir + "\target\x86_64-pc-windows-gnu\release\momento.exe"
-          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:MomentoBinaryPath
+          $version = "${{ needs.release.outputs.version }}"
+          $binaryFile64Prefix = "momento-cli-$version.windows_x86_64"
 
           # Create zipfile
-          $env:BinaryFile64Zip = "$env:BinaryFile64Prefix.zip"
-          $env:DestinationPathZip = $env:CurrentDir + "\" + $env:BinaryFile64Zip
-          Compress-Archive -LiteralPath $env:MomentoBinaryPath -DestinationPath $env:DestinationPathZip
+          $binaryFile64Zip = "$binaryFile64Prefix.zip"
+          $destinationPathZip = Get-Location + "\" + $binaryFile64Zip
+          Compress-Archive -LiteralPath $MomentoBinaryPath -DestinationPath $destinationPathZip
 
           # Build the installer
           # NB: MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
-          $env:BuildVersion = "$env:Version.0"
-          msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$env:BinaryFile64Prefix
-          $env:BinaryFile64Msi = "$env:BinaryFile64Prefix.msi"
-          $env:DestinationPathMsi = ".\windows\installer\bin\Release\$env:BinaryFile64Msi"
+          $BuildVersion = "$version.0"
+          msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$binaryFile64Prefix
+          $binaryFile64Msi = "$binaryFile64Prefix.msi"
+          $destinationPathMsi = ".\windows\installer\bin\Release\$binaryFile64Msi"
 
           # Sign the installer
-          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:DestinationPathMsi
+          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $destinationPathMsi
 
           # Write asset paths
-          $env:LatestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v$env:Version"
-          $env:LatestReleaseUri
-          $env:LatestRelease = (Invoke-WebRequest -Uri $env:LatestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
-          $env:ReleaseId = $env:LatestRelease | jq -r .id
-          $GhAsset64Msi = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$env:ReleaseId/assets?name=$env:BinaryFile64Msi"
-          $GhAsset64Zip = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$env:ReleaseId/assets?name=$env:BinaryFile64Zip"
-          echo "::set-output name=upload_url_msi::$GhAsset64Msi"
-          echo "::set-output name=upload_url_zip::$GhAsset64Zip"
-          echo "::set-output name=asset_path_msi::$env:DestinationPathMsi"
-          echo "::set-output name=asset_path_zip::$env:DestinationPathZip"
-          echo "::set-output name=asset_name_msi::$env:BinaryFile64Msi"
-          echo "::set-output name=asset_name_zip::$env:BinaryFile64Zip"
+          $latestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v$version"
+          $latestReleaseUri
+          $latestRelease = (Invoke-WebRequest -Uri $latestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
+          $releaseId = $latestRelease | jq -r .id
+          $ghAsset64Msi = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$binaryFile64Msi"
+          $ghAsset64Zip = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$binaryFile64Zip"
+          echo "::set-output name=upload_url_msi::$ghAsset64Msi"
+          echo "::set-output name=upload_url_zip::$ghAsset64Zip"
+          echo "::set-output name=asset_path_msi::$destinationPathMsi"
+          echo "::set-output name=asset_path_zip::$destinationPathZip"
+          echo "::set-output name=asset_name_msi::$binaryFile64Msi"
+          echo "::set-output name=asset_name_zip::$binaryFile64Zip"
 
       - name: Delete PFX certificate
         env:

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -249,12 +249,16 @@ jobs:
         shell: bash
 
       - name: Build
+        id: build
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
           rustup target add x86_64-pc-windows-gnu
           cargo build --release --target x86_64-pc-windows-gnu
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+          echo "::set-output name=momento_binary_path::.\target\x86_64-pc-windows-gnu\release\momento.exe"
+          $distributableFile64Prefix = "momento-cli-$env:VERSION.windows_x86_64"
+          echo "::set-output name=distributable_file_prefix::$distributableFile64Prefix"
 
       - name: Write PFX certificate file
         id: write_pfx
@@ -273,68 +277,84 @@ jobs:
           Test-Path -Path $signtool -PathType Leaf
           echo "::set-output name=signtool_path::$signtool"
 
-      - name: Sign Momento Binary
+      - name: Sign Momento binary
         env:
-          SIGNTOOL_PATH: ${{ steps.signtool.signtool_path }}
+          SIGNTOOL_PATH: ${{ steps.signtool.outputs.signtool_path }}
           CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
           CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+          MOMENTO_BINARY_PATH: ${{ steps.build.outputs.momento_binary_path }}
         run: |
-          $momentoBinaryPath = ".\target\x86_64-pc-windows-gnu\release\momento.exe"
-          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $momentoBinaryPath
+          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:MOMENTO_BINARY_PATH
 
-      - name: Create zip and installer packages
-        id: create_release
+      - name: Create zip
+        id: create_zip
         env:
-          SIGNTOOL_PATH: ${{ steps.signtool.signtool_path }}
-          CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
-          CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+          MOMENTO_BINARY_PATH: ${{ steps.build.outputs.momento_binary_path }}
+          DISTRIBUTABLE_FILE_PREFIX: ${{ steps.build.outputs.distributable_file_prefix }}
         run: |
-          # Create zipfile
-          $momentoBinaryPath = ".\target\x86_64-pc-windows-gnu\release\momento.exe"
-          $version = "${{ needs.release.outputs.version }}"
-          $binaryFile64Prefix = "momento-cli-$version.windows_x86_64"
-          $binaryFile64Zip = "$binaryFile64Prefix.zip"
-          $destinationPathZip = Get-Location + "\" + $binaryFile64Zip
-          Compress-Archive -LiteralPath $momentoBinaryPath -DestinationPath $destinationPathZip
+          $zipFilename = "$env:DISTRIBUTABLE_FILE_PREFIX.zip"
+          $zipPath = Get-Location + "\" + $zipFilename
+          Compress-Archive -LiteralPath $env:MOMENTO_BINARY_PATH -DestinationPath $zipPath
 
-          # Build the installer
-          cp $momentoBinaryPath .\windows\installer
+          echo "::set-output name=asset_path_zip::$zipPath"
+          echo "::set-output name=asset_name_zip::$zipFilename"
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Build installer
+        id: build_installer
+        env:
+          MOMENTO_BINARY_PATH: ${{ steps.build.outputs.momento_binary_path }}
+          DISTRIBUTABLE_FILE_PREFIX: ${{ steps.build.outputs.distributable_file_prefix }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          cp $env:MOMENTO_BINARY_PATH .\windows\installer
           # NB: MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
-          $BuildVersion = "$version.0"
-          msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$binaryFile64Prefix
-          $binaryFile64Msi = "$binaryFile64Prefix.msi"
-          $destinationPathMsi = ".\windows\installer\bin\Release\$binaryFile64Msi"
+          $BuildVersion = "$env:VERSION.0"
+          msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$env:DISTRIBUTABLE_FILE_PREFIX
 
-          # Sign the installer
-          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $destinationPathMsi
-
-          # Write asset paths
-          $latestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v$version"
-          $latestReleaseUri
-          $latestRelease = (Invoke-WebRequest -Uri $latestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
-          $releaseId = $latestRelease | jq -r .id
-          $ghAsset64Msi = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$binaryFile64Msi"
-          $ghAsset64Zip = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$binaryFile64Zip"
-          echo "::set-output name=upload_url_msi::$ghAsset64Msi"
-          echo "::set-output name=upload_url_zip::$ghAsset64Zip"
-          echo "::set-output name=asset_path_msi::$destinationPathMsi"
-          echo "::set-output name=asset_path_zip::$destinationPathZip"
-          echo "::set-output name=asset_name_msi::$binaryFile64Msi"
-          echo "::set-output name=asset_name_zip::$binaryFile64Zip"
+          $msiFilename = "env:DISTRIBUTABLE_FILE_PREFIX.msi"
+          $msiPath = ".\windows\installer\bin\Release\$msiFilename"
+          echo "::set-output name=asset_path_msi::$msiPath"
+          echo "::set-output name=asset_name_msi::$msiFilename"
+          
+      - name: Sign installer
+        env:
+          SIGNTOOL_PATH: ${{ steps.signtool.outputs.signtool_path }}
+          CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
+          CERT_PASSWORD: ${{ secrets.CODE_SIGNING_CERT_PASSWORD }}
+          MSI_PATH: ${{ steps.build_installer.outputs.asset_path_msi }}
+        run: |
+          & $env:SIGNTOOL_PATH sign /fd SHA256 /a /f $env:CERT_PATH /p $env:CERT_PASSWORD /tr http://timestamp.digicert.com /td SHA256 $env:MSI_PATH
 
       - name: Delete PFX certificate
         env:
           CERT_PATH: ${{ steps.write_pfx.outputs.pfx_path }}
         run: Remove-Item -Path $env:CERT_PATH
 
+      - name: Create zip and installer urls
+        id: create_release_urls
+        env:
+          ZIP_FILENAME: ${{ steps.create_zip.outputs.asset_name_zip }}
+          MSI_FILENAME: ${{ steps.create_zip.outputs.asset_name_msi }}
+        run: |
+          $latestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v${{ needs.release.outputs.version }}"
+          $latestRelease = (Invoke-WebRequest -Uri $latestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
+          $releaseId = $latestRelease | jq -r .id
+          $ghAssetMsi = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$env:MSI_FILENAME"
+          $ghAssetZip = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$env:ZIP_FILENAME"
+          echo "::set-output name=upload_url_msi::$ghAssetMsi"
+          echo "::set-output name=upload_url_zip::$ghAssetZip"
+
       - name: Upload windows_x86_64 msi
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url_msi }}
-          asset_path: ${{ steps.create_release.outputs.asset_path_msi }}
-          asset_name: ${{ steps.create_release.outputs.asset_name_msi }}
+          upload_url: ${{ steps.create_release_urls.outputs.upload_url_msi }}
+          asset_path: ${{ steps.build_installer.outputs.asset_path_msi }}
+          asset_name: ${{ steps.build_installer.outputs.asset_name_msi }}
           asset_content_type: application/octet-stream
 
       - name: Upload windows_x86_64 zip
@@ -342,9 +362,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url_zip }}
-          asset_path: ${{ steps.create_release.outputs.asset_path_zip }}
-          asset_name: ${{ steps.create_release.outputs.asset_name_zip }}
+          upload_url: ${{ steps.create_release_urls.outputs.upload_url_zip }}
+          asset_path: ${{ steps.create_zip.outputs.asset_path_zip }}
+          asset_name: ${{ steps.create_zip.outputs.asset_name_zip }}
           asset_content_type: application/zip
 
       # Commenting out building i686 since the machine doesn't seem to have i686-w64-mingw32-gcc.exe compiler installed by default.

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -336,10 +336,11 @@ jobs:
       - name: Create zip and installer urls
         id: create_release_urls
         env:
+          VERSION: ${{ needs.release.outputs.version }}
           ZIP_FILENAME: ${{ steps.create_zip.outputs.asset_name }}
           MSI_FILENAME: ${{ steps.build_installer.outputs.asset_name }}
         run: |
-          $latestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v${{ needs.release.outputs.version }}"
+          $latestReleaseUri = "https://api.github.com/repos/momentohq/momento-cli/releases/tags/v$env:VERSION"
           $latestRelease = (Invoke-WebRequest -Uri $latestReleaseUri -Method Get -Headers @{'authorization' = 'Bearer ${{ secrets.GITHUB_TOKEN }}' } | Select-Object -Property Content).Content
           $releaseId = $latestRelease | jq -r .id
           $ghAssetMsi = "https://uploads.github.com/repos/momentohq/momento-cli/releases/$releaseId/assets?name=$env:MSI_FILENAME"


### PR DESCRIPTION
We use a code signing certificate to sign the windows binary and windows installer. We also refactor the publish-windows-assets job steps to be more self contained.