### PR TITLE
chore: normalize case to be in line with winget release

### DIFF
--- a/windows/installer/MomentoCLI.wixproj
+++ b/windows/installer/MomentoCLI.wixproj
@@ -6,7 +6,7 @@
     <ProductVersion>3.10</ProductVersion>
     <ProjectGuid>3ec4cace-a121-4de6-bb52-fd0acd71c4d9</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>MomentoCLI</OutputName>
+    <OutputName>momento-cli</OutputName>
     <OutputType>Package</OutputType>
     <DefineSolutionProperties>false</DefineSolutionProperties>
   </PropertyGroup>

--- a/windows/installer/Product.wxs
+++ b/windows/installer/Product.wxs
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- NB BuildVersion is an environment variable set by CI/CD -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*" Name="Momento" Language="1033" Version="$(env.BuildVersion)" Manufacturer="Momento" UpgradeCode="7f41664a-8556-4415-8c59-2a2f079cca02">
+	<Product Id="*" Name="momento cli" Language="1033" Version="$(env.BuildVersion)" Manufacturer="momento" UpgradeCode="7f41664a-8556-4415-8c59-2a2f079cca02">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 		<!--<UIRef Id="WixUI_InstallDir" />-->
 
 		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 		<MediaTemplate EmbedCab="yes" />
 
-		<!-- Momento icon for Add/Remove Program menu -->
+		<!-- momento icon for Add/Remove Program menu -->
 		<Icon Id="icon.ico" SourceFile="Resources\icon.ico"/>
 		<Property Id="ARPPRODUCTICON" Value="icon.ico" />
 
@@ -21,7 +21,7 @@
 		<!-- License to display in install dialog -->
 		<WixVariable Id="WixUILicenseRtf" Value="Resources\license.rtf" />
 
-		<Feature Id="ProductFeature" Title="Momento CLI" Level="1">
+		<Feature Id="ProductFeature" Title="momento cli" Level="1">
 			<ComponentGroupRef Id="ProductComponents" />
 		</Feature>
 	</Product>
@@ -29,7 +29,7 @@
 	<Fragment>
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFilesFolder">
-				<Directory Id="INSTALLFOLDER" Name="Momento"/>
+				<Directory Id="INSTALLFOLDER" Name="momento"/>
 			</Directory>
 		</Directory>
 	</Fragment>


### PR DESCRIPTION
Because the company name in the copyright is lowercase ("momento"), we ensure the installer metadata and winget packages list the company name lowercased too. This PR updates the installer.