### PR TITLE
chore: integrate winget contributor feedback

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -310,9 +310,7 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           cp $env:MOMENTO_BINARY_PATH .\windows\installer
-          # NB: MSI installers are Major.minor.patch.build. Since we don't have build versions, we set that to 0.
-          # Also note the build expects this to be an environment variable
-          $env:BuildVersion = "$env:VERSION.0"
+          $env:BuildVersion = "$env:VERSION"
           msbuild .\windows\installer\MomentoCLI.wixproj /p:Configuration=Release /p:OutputName=$env:DISTRIBUTABLE_FILE_PREFIX
 
           $msiFilename = "$env:DISTRIBUTABLE_FILE_PREFIX.msi"

--- a/windows/installer/Product.wxs
+++ b/windows/installer/Product.wxs
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- NB BuildVersion is an environment variable set by CI/CD -->
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*" Name="momento cli" Language="1033" Version="$(env.BuildVersion)" Manufacturer="momento" UpgradeCode="7f41664a-8556-4415-8c59-2a2f079cca02">
+	<Product Id="*" Name="Momento CLI" Language="1033" Version="$(env.BuildVersion)" Manufacturer="Momento" UpgradeCode="7f41664a-8556-4415-8c59-2a2f079cca02">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 		<!--<UIRef Id="WixUI_InstallDir" />-->
 
 		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
 		<MediaTemplate EmbedCab="yes" />
 
-		<!-- momento icon for Add/Remove Program menu -->
+		<!-- Momento icon for Add/Remove Program menu -->
 		<Icon Id="icon.ico" SourceFile="Resources\icon.ico"/>
 		<Property Id="ARPPRODUCTICON" Value="icon.ico" />
 
@@ -21,7 +21,7 @@
 		<!-- License to display in install dialog -->
 		<WixVariable Id="WixUILicenseRtf" Value="Resources\license.rtf" />
 
-		<Feature Id="ProductFeature" Title="momento cli" Level="1">
+		<Feature Id="ProductFeature" Title="Momento CLI" Level="1">
 			<ComponentGroupRef Id="ProductComponents" />
 		</Feature>
 	</Product>
@@ -29,7 +29,7 @@
 	<Fragment>
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFilesFolder">
-				<Directory Id="INSTALLFOLDER" Name="momento"/>
+				<Directory Id="INSTALLFOLDER" Name="Momento"/>
 			</Directory>
 		</Directory>
 	</Fragment>


### PR DESCRIPTION
WinGet has conventions regarding the manufacturer name and application name. The WinGet metadata must also match this. Here we adjust the manufacturer name and application name to be title cased. We also remove the build number from the installer version.