### PR TITLE
chore: use momento machine pat for winget update

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -429,7 +429,7 @@ jobs:
         env:
           INSTALLER_URL: ${{ steps.build_installer_url.outputs.installer_url }}
           VERSION: ${{ needs.release.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
         run: .\wingetcreate.exe update momento.cli -s -v $env:VERSION -u $env:INSTALLER_URL -t $env:GITHUB_TOKEN
           
   update-homebrew-formula:


### PR DESCRIPTION
We believe that the `wingetcreate update` command requires
fine-grained permissions to create a pull request from a fork. Because
of this we try using the momento machine PAT.
