### PR TITLE
fix: don't log confusing message if the user runs configure a second time

### DIFF
--- a/src/commands/configure/configure_cli.rs
+++ b/src/commands/configure/configure_cli.rs
@@ -67,7 +67,8 @@ pub async fn configure_momento(quick: bool, profile_name: &str) -> Result<(), Cl
         ),
         Err(e) => {
             if e.msg.contains("already exists") {
-                console_info!("{} as the default already exists", config.cache);
+                // Nothing to do here; the cache already exists but users won't find that particularly
+                // interesting.
             } else {
                 return Err(e);
             }


### PR DESCRIPTION
Prior to this commit if the user ran configure more than once, on the second and subsequent attempts they would get a confusing message printed about the default cache already existing.  This commit removes that message as it doesn't provide any real value to the user.