### PR TITLE
feat: Topics preview

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install protoc
-        run: ./install_protoc_linux.sh
+        run: ./scripts/install_protoc_linux.sh
 
       - name: Install prerequisites
         shell: bash
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install protoc
-        run: ./install_protoc_osx.sh
+        run: ./scripts/install_protoc_osx.sh
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install protoc
-        run: ./install_protoc_windows.sh
+        run: ./scripts/install_protoc_windows.sh
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -67,6 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install protoc
+        run: ./install_protoc_linux.sh
+
       - name: Install prerequisites
         shell: bash
         run: |
@@ -181,6 +184,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install protoc
+        run: ./install_protoc_osx.sh
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -232,6 +238,9 @@ jobs:
       msi_filename: ${{ steps.build_installer.outputs.asset_name }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install protoc
+        run: ./install_protoc_windows.sh
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -240,7 +240,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install protoc
-        run: ./scripts/install_protoc_windows.sh
+        run: choco install protoc
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -31,7 +31,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
-          
+
+      - name: Install protoc
+        run: ./install_protoc_linux.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
 
       - name: Install protoc
-        run: ./install_protoc_linux.sh
+        run: ./scripts/install_protoc_linux.sh
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Install protoc
         run: ./scripts/install_protoc_linux.sh
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: rustfmt
         run: cargo fmt -- --check
       - name: Rigorous lint via Clippy
@@ -36,6 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install protoc
+        run: ./scripts/install_protoc_linux.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install protoc
-        run: ./scripts/install_protoc_windows.sh
+        run: choco install protoc
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install protoc
-        run: ./install_protoc_linux.sh
+        run: ./scripts/install_protoc_linux.sh
 
       - name: rustfmt
         run: cargo fmt -- --check
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install protoc
-        run: ./install_protoc_windows.sh
+        run: ./scripts/install_protoc_windows.sh
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install protoc
+        run: ./install_protoc_linux.sh
+
       - name: rustfmt
         run: cargo fmt -- --check
       - name: Rigorous lint via Clippy
@@ -37,6 +41,9 @@ jobs:
           toolchain: stable
           components: rustfmt
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build
         run: cargo build --verbose --features ${{ matrix.feature }}
       - name: Create .momento directory
@@ -74,8 +81,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: i guess windows-latest does not have protoc or cmake but we need protoc
-        run: choco install protoc
+
+      - name: Install protoc
+        run: ./install_protoc_windows.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install protoc
-        run: ./install_protoc_linux.sh
+        run: ./scripts/install_protoc_linux.sh
 
       - name: rustfmt
         run: cargo fmt -- --check
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install protoc
-        run: ./install_protoc_linux.sh
+        run: ./scripts/install_protoc_linux.sh
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install protoc
-        run: ./install_protoc_linux.sh
+        run: ./scripts/install_protoc_linux.sh
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install protoc
+        run: ./install_protoc_linux.sh
+
       - name: rustfmt
         run: cargo fmt -- --check
       - name: Rigorous lint via Clippy
@@ -32,6 +36,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install protoc
+        run: ./install_protoc_linux.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -74,8 +82,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: i guess windows-latest does not have protoc or cmake but we need protoc
-        run: choco install protoc
+
+      - name: Install protoc
+        run: ./install_protoc_linux.sh
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.6"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2504b827a8bef941ba3dd64bdffe9cf56ca182908a147edd6189c95fbcae7d"
+checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -100,9 +100,9 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
  "tower-http",
  "tower-layer",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
+checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
 dependencies = [
  "async-trait",
  "bytes",
@@ -121,6 +121,9 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -243,15 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -551,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -822,9 +816,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "memchr"
@@ -862,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.7.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983a6eda8e3582772087a1221d8a5a782e02bf6f790387923a63339d658d163c"
+checksum = "711e204d396c31110ceb6c90bc0ebfa0317b27fd7c8a8d03f35ac79e8e07b7b8"
 dependencies = [
  "chrono",
  "jsonwebtoken",
@@ -873,6 +867,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "thiserror",
  "tonic",
 ]
 
@@ -903,9 +898,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.18.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426dadd39866ada5146d0a7bace63a09de83c5b892847905ec2bc0379455fbd2"
+checksum = "0a510fd561fa0da444787b58673a978ae8bc06283f57b2bfcd516f8ac1b39b64"
 dependencies = [
  "prost",
  "tonic",
@@ -1114,18 +1109,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1225,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.10.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc03e116981ff7d8da8e5c220e374587b98d294af7ba7dd7fda761158f00086f"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1235,31 +1230,31 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.10.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a1118354442de7feb8a2a76f3d80ef01426bd45542c8c1fdffca41a758f846"
+checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes",
- "cfg-if",
- "cmake",
  "heck",
  "itertools",
  "lazy_static",
  "log",
  "multimap",
  "petgraph",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
+ "syn",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1270,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.10.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes",
  "prost",
@@ -1507,6 +1502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1734,18 +1735,18 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1932,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1968,9 +1969,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1981,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1993,8 +1994,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2021,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ home = "0.5.3"
 toml = "^0.6.0"
 configparser = "3.0.0"
 regex = "1"
-momento = "0.7.2"
+momento = { version = "0.21" }
 qrcode = "0.12.0"
 webbrowser = "^0.8.4"
 

--- a/scripts/install_protoc.sh
+++ b/scripts/install_protoc.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -x
+
+VERSION=21.9
+
+function install_protoc() {
+    os=$1
+    mkdir temp
+    pushd temp
+        curl -L https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-$os.zip -o protoc.zip
+        unzip -o protoc.zip -d protoc
+        sudo mv protoc/bin/* /usr/local/bin/
+        sudo mv protoc/include/* /usr/local/include/
+    popd
+    rm -rf temp
+}

--- a/scripts/install_protoc_linux.sh
+++ b/scripts/install_protoc_linux.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source $(dirname "$0")/install_protoc.sh
+install_protoc "linux-x86_64"

--- a/scripts/install_protoc_osx.sh
+++ b/scripts/install_protoc_osx.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source $(dirname "$0")/install_protoc.sh
+install_protoc "osx-x86_64"

--- a/scripts/install_protoc_windows.sh
+++ b/scripts/install_protoc_windows.sh
@@ -1,0 +1,1 @@
+choco install protoc

--- a/src/commands/cache/cache_cli.rs
+++ b/src/commands/cache/cache_cli.rs
@@ -1,6 +1,6 @@
 use log::debug;
-use std::num::NonZeroU64;
 use std::process::exit;
+use std::time::Duration;
 
 use crate::{
     error::CliError,
@@ -60,9 +60,7 @@ pub async fn set(
             &cache_name,
             key,
             value,
-            Some(NonZeroU64::new(ttl_seconds).ok_or_else(|| CliError {
-                msg: "could not create a non-zero u64".to_string(),
-            })?),
+            Some(Duration::from_secs(ttl_seconds)),
         ),
     )
     .await
@@ -81,14 +79,14 @@ pub async fn get(
 
     let response = interact_with_momento("getting...", client.get(&cache_name, key)).await?;
     match response.result {
-        momento::response::cache_get_response::MomentoGetStatus::HIT => {
+        momento::response::MomentoGetStatus::HIT => {
             console_data!("{}", response.as_string())
         }
-        momento::response::cache_get_response::MomentoGetStatus::MISS => {
+        momento::response::MomentoGetStatus::MISS => {
             debug!("cache miss");
             exit(1)
         }
-        momento::response::cache_get_response::MomentoGetStatus::ERROR => {
+        momento::response::MomentoGetStatus::ERROR => {
             debug!("something terrible happened with the wire protocol");
             exit(13)
         }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,3 +4,5 @@ pub mod configure;
 #[cfg(feature = "login")]
 pub mod login;
 pub mod signingkey;
+
+pub mod topic;

--- a/src/commands/topic/mod.rs
+++ b/src/commands/topic/mod.rs
@@ -1,0 +1,20 @@
+use momento::{preview::topics::Subscription, MomentoResult};
+
+use crate::utils::console::console_data;
+
+pub async fn print_subscription(mut subscription: Subscription) -> MomentoResult<()> {
+    while let Some(item) = subscription.item().await? {
+        match item {
+            momento::preview::topics::SubscriptionItem::Value(value) => match value.kind {
+                momento::preview::topics::ValueKind::Text(text) => console_data!("{text}"),
+                momento::preview::topics::ValueKind::Binary(binary) => {
+                    console_data!("{{\"kind\": \"binary\", \"length\": {}}}", binary.len())
+                }
+            },
+            momento::preview::topics::SubscriptionItem::Discontinuity(discontinuity) => {
+                console_data!("{discontinuity:?}")
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ enum Subcommand {
     ///
     /// To create a topic, subscribe to it.
     /// To delete a topic, stop subscribing to it.
-    #[command(verbatim_doc_comment)]
+    #[command(verbatim_doc_comment, hide = true)]
     Topic {
         #[arg(
             long = "endpoint",

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -1,9 +1,6 @@
-use std::{future::Future, num::NonZeroU64};
+use std::{future::Future, time::Duration};
 
-use momento::{
-    response::error::MomentoError,
-    simple_cache_client::{SimpleCacheClient, SimpleCacheClientBuilder},
-};
+use momento::{response::MomentoError, SimpleCacheClient, SimpleCacheClientBuilder};
 
 use crate::{error::CliError, utils::console::console_data};
 
@@ -13,9 +10,7 @@ pub async fn get_momento_client(
 ) -> Result<SimpleCacheClient, CliError> {
     SimpleCacheClientBuilder::new_with_explicit_agent_name(
         auth_token,
-        NonZeroU64::new(100).ok_or_else(|| CliError {
-            msg: "".to_string(),
-        })?,
+        Duration::from_secs(120),
         "cli",
         endpoint,
     )


### PR DESCRIPTION
Add a simple ability to publish and subscribe to momento topics.
Once this feature is stabilized we can remove the preview header.

example:
```bash
 # terminal 1
momento topic subscribe a_topic
```
```bash
 # terminal 2
momento topic publish a_topic 'hello there'
```

```
Interact with topics
!!                            !!
!!       Preview feature      !!
!!  Your feedback is welcome  !!
!!                            !!
These commands requires a cache, which serves as a namespace
for your topics. If you haven't already, call `cache create`
to make one!

To create a topic, subscribe to it.
To delete a topic, stop subscribing to it.

Usage: momento topic [OPTIONS] <COMMAND>

Commands:
  publish
          Publish a value to all subscribers of a topic
  subscribe
          Subscribe to messages coming in on a topic
  help
          Print this message or the help of the given subcommand(s)

Options:
  -e, --endpoint <ENDPOINT>
          An explicit hostname to use; for example, cell-us-east-1-1.prod.a.momentohq.com

      --verbose
          Log more information

  -p, --profile <PROFILE>
          User profile

          [default: default]

  -h, --help
          Print help (see a summary with '-h')
```

Also updates to the latest rust sdk. A few unrelated minor things
changed, like a couple renames and repackages.
