### PR TITLE
chore: add some initial basic tests for config/creds ini interactions

### DIFF
--- a/src/commands/account.rs
+++ b/src/commands/account.rs
@@ -33,7 +33,7 @@ fn get_signup_endpoint() -> String {
 
 pub async fn signup_user(email: String, cloud: String, region: String) -> Result<(), CliError> {
     let endpoint = get_signup_endpoint();
-    let url = format!("{}/token/create", endpoint);
+    let url = format!("{endpoint}/token/create");
 
     let body = &CreateTokenBody {
         email,

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -26,8 +26,7 @@ fn login_with_browser(action: LoginAction) -> EarlyOutActionResult {
                 None
             }
             Err(e) => Some(Err(MomentoError::ClientSdkError(format!(
-                "Unable to open browser: {:?}",
-                e
+                "Unable to open browser: {e:?}"
             )))),
         },
         momento::auth::LoginAction::ShowMessage(message) => {
@@ -52,8 +51,7 @@ fn login_with_qr_code(action: LoginAction) -> EarlyOutActionResult {
                     None
                 }
                 Err(e) => Some(Err(MomentoError::ClientSdkError(format!(
-                    "Unable to generate qr code: {:?}",
-                    e
+                    "Unable to generate qr code: {e:?}"
                 )))),
             }
         }

--- a/src/utils/console.rs
+++ b/src/utils/console.rs
@@ -9,7 +9,7 @@
 /// //stderr> Hello, world!
 /// ```
 pub fn output_info(msg: &str) {
-    eprintln!("{}", msg);
+    eprintln!("{msg}");
 }
 
 /// The console print macro for non-verbose output.
@@ -43,7 +43,7 @@ pub(crate) use console_info;
 // //> {"key": "value"}
 // ```
 pub fn output_data(msg: &str) {
-    println!("{}", msg);
+    println!("{msg}");
 }
 
 /// The console print macro for cache response data.

--- a/src/utils/ini_config.rs
+++ b/src/utils/ini_config.rs
@@ -1,41 +1,23 @@
-use configparser::ini::Ini;
 use regex::Regex;
 
 use crate::{
     config::{Config, Credentials, FileTypes},
     error::CliError,
-    utils::file::ini_write_to_file,
 };
 
-pub async fn add_new_profile_to_credentials(
-    profile_name: &str,
-    credentials_file_path: &str,
-    credentials: Credentials,
-) -> Result<(), CliError> {
-    let mut ini_map = Ini::new_cs();
-    // Empty default_section for Ini instance so that "default" will be used as a section
-    ini_map.set_default_section("");
-    ini_map.set(profile_name, "token", Some(credentials.token));
-    match ini_write_to_file(ini_map, credentials_file_path).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e),
-    }
+pub fn create_new_credentials_profile(profile_name: &str, credentials: Credentials) -> Vec<String> {
+    vec![
+        format!("[{profile_name}]"),
+        format!("token={}", credentials.token),
+    ]
 }
 
-pub async fn add_new_profile_to_config(
-    profile_name: &str,
-    config_file_path: &str,
-    config: Config,
-) -> Result<(), CliError> {
-    let mut ini_map = Ini::new_cs();
-    // Empty default_section for Ini instance so that "default" will be used as a section
-    ini_map.set_default_section("");
-    ini_map.set(profile_name, "cache", Some(config.cache));
-    ini_map.set(profile_name, "ttl", Some(config.ttl.to_string()));
-    match ini_write_to_file(ini_map, config_file_path).await {
-        Ok(_) => Ok(()),
-        Err(e) => Err(e),
-    }
+pub fn create_new_config_profile(profile_name: &str, config: Config) -> Vec<String> {
+    vec![
+        format!("[{profile_name}]"),
+        format!("cache={}", config.cache),
+        format!("ttl={}", config.ttl),
+    ]
 }
 
 pub fn update_profile_values(
@@ -166,13 +148,13 @@ fn replace_value(
                 Ok(r) => r,
                 Err(e) => {
                     return Err(CliError {
-                        msg: format!("invalid regex expression is provided, error: {}", e),
+                        msg: format!("invalid regex expression is provided, error: {e}"),
                     })
                 }
             };
             let result = token_regex.replace(
                 updated_file_contents[index].as_str(),
-                format!("token={}\n", cr.token.as_str()),
+                format!("token={}", cr.token.as_str()),
             );
             updated_file_contents[index] = result.to_string();
             Ok(updated_file_contents)
@@ -182,13 +164,13 @@ fn replace_value(
                 Ok(r) => r,
                 Err(e) => {
                     return Err(CliError {
-                        msg: format!("invalid regex expression is provided, error: {}", e),
+                        msg: format!("invalid regex expression is provided, error: {e}"),
                     })
                 }
             };
             let result = cache_regex.replace(
                 updated_file_contents[index].as_str(),
-                format!("cache={}\n", cf.cache.as_str()),
+                format!("cache={}", cf.cache.as_str()),
             );
             updated_file_contents[index] = result.to_string();
 
@@ -196,16 +178,272 @@ fn replace_value(
                 Ok(r) => r,
                 Err(e) => {
                     return Err(CliError {
-                        msg: format!("invalid regex expression is provided, error: {}", e),
+                        msg: format!("invalid regex expression is provided, error: {e}"),
                     })
                 }
             };
             let result = ttl_regex.replace(
                 updated_file_contents[index].as_str(),
-                format!("ttl={}\n", cf.ttl.to_string().as_str()),
+                format!("ttl={}", cf.ttl.to_string().as_str()),
             );
             updated_file_contents[index] = result.to_string();
             Ok(updated_file_contents)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{Config, Credentials, FileTypes};
+    use crate::utils::ini_config::{
+        create_new_config_profile, create_new_credentials_profile, update_profile_values,
+    };
+
+    fn test_file_content(untrimmed_file_contents: &str) -> String {
+        format!("{}\n", untrimmed_file_contents.trim())
+    }
+
+    #[test]
+    fn create_new_credentials_profile_happy_path() {
+        let profile_text = create_new_credentials_profile(
+            "default",
+            Credentials {
+                token: "awesome-token".to_string(),
+            },
+        )
+        .join("\n");
+        let expected_text = test_file_content(
+            "
+[default]
+token=awesome-token
+        ",
+        );
+        assert_eq!(expected_text.trim(), profile_text);
+    }
+
+    #[test]
+    fn create_new_config_profile_happy_path() {
+        let profile_text = create_new_config_profile(
+            "default",
+            Config {
+                cache: "awesome-cache".to_string(),
+                ttl: 90210,
+            },
+        )
+        .join("\n");
+        let expected_text = test_file_content(
+            "
+[default]
+cache=awesome-cache
+ttl=90210
+        ",
+        );
+        assert_eq!(expected_text.trim(), profile_text)
+    }
+
+    #[test]
+    fn update_profile_values_credentials_one_existing_profile() {
+        // TODO
+        // TODO these line number bits are fragile and we should refactor to prevent them from
+        // being necessary.  Will hit in a subsequent PR.
+        // TODO
+        let profile_line_numbers = vec![1];
+        let matching_profile_starting_line_num = 1;
+        // TODO
+        // TODO can we change the signature to take Vec<&str> so we don't need this map?
+        // TODO
+        let file_contents: Vec<String> = test_file_content(
+            "
+[default]
+token=invalidtoken
+        ",
+        )
+        .split('\n')
+        .map(|line| line.to_string())
+        .collect();
+        let creds = Credentials {
+            token: "newtoken".to_string(),
+        };
+        let file_types = FileTypes::Credentials(creds);
+        let result = update_profile_values(
+            profile_line_numbers,
+            matching_profile_starting_line_num,
+            file_contents,
+            file_types,
+        );
+        assert!(result.is_ok());
+        let new_content = result.expect("d'oh").join("\n");
+
+        let expected_content = test_file_content(
+            "
+[default]
+token=newtoken
+        ",
+        );
+
+        assert_eq!(expected_content, new_content);
+    }
+
+    #[test]
+    fn update_profile_values_credentials_three_existing_profiles() {
+        // TODO
+        // TODO these line number bits are fragile and we should refactor to prevent them from
+        // being necessary.  Will hit in a subsequent PR.
+        // TODO
+        let profile_line_numbers = vec![1, 3, 5];
+        let matching_profile_starting_line_num = 3;
+        // TODO
+        // TODO can we change the signature to take Vec<&str> so we don't need this map?
+        // TODO
+        let file_contents = test_file_content(
+            "
+[taco]
+token=invalidtoken
+
+[default]
+token=anotherinvalidtoken
+
+[habanero]
+token=spicytoken
+        ",
+        )
+        .split('\n')
+        .map(|line| line.to_string())
+        .collect();
+        let creds = Credentials {
+            token: "newtoken".to_string(),
+        };
+        let file_types = FileTypes::Credentials(creds);
+        let result = update_profile_values(
+            profile_line_numbers,
+            matching_profile_starting_line_num,
+            file_contents,
+            file_types,
+        );
+        assert!(result.is_ok());
+        let new_content = result.expect("d'oh").join("\n");
+
+        let expected_content = test_file_content(
+            "
+[taco]
+token=invalidtoken
+
+[default]
+token=newtoken
+
+[habanero]
+token=spicytoken
+        ",
+        );
+
+        assert_eq!(expected_content, new_content);
+    }
+
+    #[test]
+    fn update_profile_values_config_one_existing_profile() {
+        // TODO
+        // TODO these line number bits are fragile and we should refactor to prevent them from
+        // being necessary.  Will hit in a subsequent PR.
+        // TODO
+        let profile_line_numbers = vec![1];
+        let matching_profile_starting_line_num = 1;
+        // TODO
+        // TODO can we change the signature to take Vec<&str> so we don't need this map?
+        // TODO
+        let file_contents: Vec<String> = test_file_content(
+            "
+[default]
+cache=default-cache
+ttl=600
+        ",
+        )
+        .split('\n')
+        .map(|line| line.to_string())
+        .collect();
+        let config = Config {
+            cache: "new-cache".to_string(),
+            ttl: 90210,
+        };
+        let file_types = FileTypes::Config(config);
+        let result = update_profile_values(
+            profile_line_numbers,
+            matching_profile_starting_line_num,
+            file_contents,
+            file_types,
+        );
+        assert!(result.is_ok());
+        let new_content = result.expect("d'oh").join("\n");
+
+        let expected_content = test_file_content(
+            "
+[default]
+cache=new-cache
+ttl=90210
+        ",
+        );
+
+        assert_eq!(expected_content, new_content);
+    }
+
+    #[test]
+    fn update_profile_values_config_three_existing_profiles() {
+        // TODO
+        // TODO these line number bits are fragile and we should refactor to prevent them from
+        // being necessary.  Will hit in a subsequent PR.
+        // TODO
+        let profile_line_numbers = vec![1, 5, 9];
+        let matching_profile_starting_line_num = 5;
+        // TODO
+        // TODO can we change the signature to take Vec<&str> so we don't need this map?
+        // TODO
+        let file_contents = test_file_content(
+            "
+[taco]
+cache=yummy-cache
+ttl=600
+
+[default]
+cache=default-cache
+ttl=600
+
+[habanero]
+cache=spicy-cache
+ttl=600
+        ",
+        )
+        .split('\n')
+        .map(|line| line.to_string())
+        .collect();
+        let config = Config {
+            cache: "new-cache".to_string(),
+            ttl: 90210,
+        };
+        let file_types = FileTypes::Config(config);
+        let result = update_profile_values(
+            profile_line_numbers,
+            matching_profile_starting_line_num,
+            file_contents,
+            file_types,
+        );
+        assert!(result.is_ok());
+        let new_content = result.expect("d'oh").join("\n");
+
+        let expected_content = test_file_content(
+            "
+[taco]
+cache=yummy-cache
+ttl=600
+
+[default]
+cache=new-cache
+ttl=90210
+
+[habanero]
+cache=spicy-cache
+ttl=600
+        ",
+        );
+
+        assert_eq!(expected_content, new_content);
     }
 }

--- a/src/utils/user.rs
+++ b/src/utils/user.rs
@@ -4,11 +4,11 @@ use configparser::ini::Ini;
 use crate::{
     config::{Config, Credentials},
     error::CliError,
-    utils::file::{get_config_file_path, get_credentials_file_path, read_file},
+    utils::file::{get_config_file_path, get_credentials_file_path, read_ini_file},
 };
 
 #[cfg(feature = "login")]
-use super::file::ini_write_to_file;
+use crate::utils::file::write_to_file;
 
 fn get_session_token(credentials: &Ini) -> Option<String> {
     let session_token = credentials.get(".momento_session", "token");
@@ -52,7 +52,18 @@ pub async fn clobber_session_token(
 ) -> Result<(), CliError> {
     let mut credentials_file = read_credentials().await?;
     set_session_token(&mut credentials_file, session_token, valid_for_seconds);
-    ini_write_to_file(credentials_file, &get_credentials_file_path()?).await?;
+    // TODO
+    // TODO this is silly, should change write_to_file to take a String or have one fn for vec and one for string
+    // TODO
+    write_to_file(
+        &get_credentials_file_path()?,
+        credentials_file
+            .writes()
+            .split('\n')
+            .map(|line| line.to_string())
+            .collect(),
+    )
+    .await?;
     Ok(())
 }
 
@@ -74,19 +85,19 @@ pub async fn get_creds_for_profile(profile: &str) -> Result<Credentials, CliErro
         })
     }).unwrap_or_else(|| {
         Err(CliError{
-            msg: format!("failed to get credentials for profile {}, please run 'momento configure' to configure your profile", profile)
+            msg: format!("failed to get credentials for profile {profile}, please run 'momento configure' to configure your profile")
         })
     })
 }
 
 async fn read_credentials() -> Result<Ini, CliError> {
     let path = get_credentials_file_path()?;
-    read_file(&path).await
+    read_ini_file(&path).await
 }
 
 pub async fn get_config_for_profile(profile: &str) -> Result<Config, CliError> {
     let path = get_config_file_path()?;
-    let configs = match read_file(&path).await {
+    let configs = match read_ini_file(&path).await {
         Ok(c) => c,
         Err(e) => return Err(CliError {
             msg: format!("failed to read credentials, please run 'momento configure' to setup credentials. Root cause: {e:?}")
@@ -96,14 +107,14 @@ pub async fn get_config_for_profile(profile: &str) -> Result<Config, CliError> {
     let cache_result = match configs.get(profile, "cache") {
         Some(c) => c,
         None => return Err(CliError{
-            msg: format!("failed to get cache config for profile {}, please run 'momento configure' to configure your profile", profile)
+            msg: format!("failed to get cache config for profile {profile}, please run 'momento configure' to configure your profile")
         }),
     };
 
     let ttl_result = match configs.get(profile, "ttl") {
         Some(c) => c,
         None => return Err(CliError{
-            msg: format!("failed to get ttl config for profile {}, please run 'momento configure' to configure your profile", profile)
+            msg: format!("failed to get ttl config for profile {profile}, please run 'momento configure' to configure your profile")
         }),
     };
 


### PR DESCRIPTION
This commit just adds some early unit tests for the ini_config
module.  A minor refactor was required for some separation of
concerns so that the tests could be written without writing
files to disk.

In subsequent commits the functions in the ini_config will be
refactored further to make them more testable, but this commit
gets the tests in place so that we can hopefully ensure that
we don't break any functionality in the subsequent refactor.

The end goal here is to fix some issues that users reported
where empty tokens don't get updated properly, or leading/trailing
whitespace entered in the CLI input cause corruption to the
files; this will be addressed in later commits once the code
can be tested more easily.
