### PR TITLE
fix: add tests to cover case with empty token in config file, fix bug

### DIFF
--- a/src/commands/configure/configure_cli.rs
+++ b/src/commands/configure/configure_cli.rs
@@ -433,4 +433,29 @@ token=awesome-token
         );
         assert_eq!(expected.trim_end(), updated.join("\n"));
     }
+
+    #[test]
+    fn add_or_update_profile_creds_existing_token_is_empty() {
+        let existing_content = test_content_to_lines(
+            "
+[default]
+token=
+        ",
+        );
+        let updated = add_or_update_profile(
+            "default",
+            FileTypes::Credentials(Credentials {
+                token: "awesome-token".to_string(),
+            }),
+            existing_content,
+        )
+        .expect("d'oh");
+        let expected = test_file_content(
+            "
+[default]
+token=awesome-token
+        ",
+        );
+        assert_eq!(expected.trim_end(), updated.join("\n"));
+    }
 }

--- a/src/utils/ini_config.rs
+++ b/src/utils/ini_config.rs
@@ -158,7 +158,7 @@ fn replace_value(
 
     match file_types {
         FileTypes::Credentials(cr) => {
-            let token_regex = match Regex::new(r"^token\s*=\s*([\w\.-]+)\s*$") {
+            let token_regex = match Regex::new(r"^token\s*=\s*([\w\.-]*)\s*$") {
                 Ok(r) => r,
                 Err(e) => {
                     return Err(CliError {
@@ -174,7 +174,7 @@ fn replace_value(
             Ok(updated_file_contents)
         }
         FileTypes::Config(cf) => {
-            let cache_regex = match Regex::new(r"^cache\s*=\s*([\w-]+)\s*$") {
+            let cache_regex = match Regex::new(r"^cache\s*=\s*([\w-]*)\s*$") {
                 Ok(r) => r,
                 Err(e) => {
                     return Err(CliError {
@@ -188,7 +188,7 @@ fn replace_value(
             );
             updated_file_contents[index] = result.to_string();
 
-            let ttl_regex = match Regex::new(r"^ttl\s*=\s*([\d]+)\s*$") {
+            let ttl_regex = match Regex::new(r"^ttl\s*=\s*([\d]*)\s*$") {
                 Ok(r) => r,
                 Err(e) => {
                     return Err(CliError {
@@ -309,6 +309,33 @@ ttl=90210
             "
 [default]
 token=invalidtoken
+        ",
+        );
+        let file_lines: Vec<&str> = file_contents.split('\n').collect();
+        let creds = Credentials {
+            token: "newtoken".to_string(),
+        };
+        let file_types = FileTypes::Credentials(creds);
+        let result = update_profile_values("default", &file_lines, file_types);
+        assert!(result.is_ok());
+        let new_content = result.expect("d'oh").join("\n");
+
+        let expected_content = test_file_content(
+            "
+[default]
+token=newtoken
+        ",
+        );
+
+        assert_eq!(expected_content, new_content);
+    }
+
+    #[test]
+    fn update_profile_values_credentials_one_existing_profile_with_empty_token() {
+        let file_contents = test_file_content(
+            "
+[default]
+token=
         ",
         );
         let file_lines: Vec<&str> = file_contents.split('\n').collect();


### PR DESCRIPTION
A user reported that if the credentials file has an empty token (e.g. if they pressed enter without pasting a token in when running the configure command), subsequent calls to the configure command did not update the file properly.

This commit adds test coverage for this case and fixes the bug that was preventing the new value from being written.