### PR TITLE
chore: simplify logic for updating config/credentials files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "configparser",
  "env_logger",
  "home",
+ "lazy_static",
  "log",
  "momento",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.19"
 colored = "2.0.0"
 home = "0.5.3"
 toml = "^0.6.0"
+lazy_static = "1.4.0"
 configparser = "3.0.0"
 regex = "1"
 momento = { version = "0.21" }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,12 +3,6 @@ use serde::{Deserialize, Serialize};
 pub const ENV_VAR_NAME_MOMENTO_CONFIG_DIR: &str = "MOMENTO_CONFIG_DIR";
 pub const DEFAULT_CACHE_NAME: &str = "default-cache";
 
-#[derive(Clone)]
-pub enum FileTypes {
-    Config(Config),
-    Credentials(Credentials),
-}
-
 #[derive(Deserialize, Serialize, Clone, Default)]
 pub struct Config {
     pub cache: String,

--- a/src/utils/ini_config.rs
+++ b/src/utils/ini_config.rs
@@ -36,52 +36,39 @@ pub fn update_credentials_profile(
 
     let existing_profile_starting_line_num =
         find_existing_profile_start(file_contents, profile_name);
+    let existing_profile_index = existing_profile_line_numbers
+        .iter()
+        .position(|ln| *ln == existing_profile_starting_line_num)
+        .ok_or(CliError {
+            msg: "Unable to find index of current profile".to_string(),
+        })?;
 
     let num_of_profiles = existing_profile_line_numbers.len();
     let file_contents_len = file_contents.len();
     let mut updated_file_contents: Vec<String> = Vec::new();
+    let start_line = existing_profile_starting_line_num;
+    let end_line = if existing_profile_index == (num_of_profiles - 1) {
+        file_contents_len
+    } else {
+        existing_profile_line_numbers[existing_profile_index + 1]
+    };
     for (counter, line_num) in existing_profile_line_numbers.iter().enumerate() {
         if existing_profile_starting_line_num == *line_num {
-            // Case where profile_name is the only or last item in existing_profile_line_numbers
-            if counter == num_of_profiles - 1 {
-                for n in *line_num..file_contents_len {
-                    if n == *line_num {
-                        updated_file_contents =
-                            match replace_credentials_value(file_contents, n, &credentials) {
-                                Ok(v) => v,
-                                Err(e) => return Err(e),
-                            }
-                    } else {
-                        updated_file_contents = match replace_credentials_value(
-                            &updated_file_contents.clone(),
-                            n,
-                            &credentials,
-                        ) {
+            for n in start_line..end_line {
+                if n == existing_profile_line_numbers[counter] {
+                    updated_file_contents =
+                        match replace_credentials_value(file_contents, n, &credentials) {
                             Ok(v) => v,
                             Err(e) => return Err(e),
                         }
-                    }
-                }
-            } else {
-                // Case where profile_name is at the beginning or at the middle of existing_profile_line_numbers
-                for n in existing_profile_line_numbers[counter]
-                    ..existing_profile_line_numbers[counter + 1]
-                {
-                    if n == existing_profile_line_numbers[counter] {
-                        updated_file_contents =
-                            match replace_credentials_value(file_contents, n, &credentials) {
-                                Ok(v) => v,
-                                Err(e) => return Err(e),
-                            }
-                    } else {
-                        updated_file_contents = match replace_credentials_value(
-                            &updated_file_contents.clone(),
-                            n,
-                            &credentials,
-                        ) {
-                            Ok(v) => v,
-                            Err(e) => return Err(e),
-                        }
+                } else {
+                    updated_file_contents = match replace_credentials_value(
+                        &updated_file_contents.clone(),
+                        n,
+                        &credentials,
+                    ) {
+                        Ok(v) => v,
+                        Err(e) => return Err(e),
                     }
                 }
             }
@@ -106,47 +93,37 @@ pub fn update_config_profile<T: AsRef<str>>(
 
     let existing_profile_starting_line_num =
         find_existing_profile_start(file_contents, profile_name);
+    let existing_profile_index = existing_profile_line_numbers
+        .iter()
+        .position(|ln| *ln == existing_profile_starting_line_num)
+        .ok_or(CliError {
+            msg: "Unable to find index of current profile".to_string(),
+        })?;
 
     let num_of_profiles = existing_profile_line_numbers.len();
     let file_contents_len = file_contents.len();
     let mut updated_file_contents: Vec<String> = Vec::new();
+    let start_line = existing_profile_starting_line_num;
+    let end_line = if existing_profile_index == (num_of_profiles - 1) {
+        file_contents_len
+    } else {
+        existing_profile_line_numbers[existing_profile_index + 1]
+    };
+
     for (counter, line_num) in existing_profile_line_numbers.iter().enumerate() {
         if existing_profile_starting_line_num == *line_num {
-            // Case where profile_name is the only or last item in existing_profile_line_numbers
-            if counter == num_of_profiles - 1 {
-                for n in *line_num..file_contents_len {
-                    if n == *line_num {
-                        updated_file_contents =
-                            match replace_config_value(file_contents, n, &config) {
-                                Ok(v) => v,
-                                Err(e) => return Err(e),
-                            }
-                    } else {
-                        updated_file_contents =
-                            match replace_config_value(&updated_file_contents.clone(), n, &config) {
-                                Ok(v) => v,
-                                Err(e) => return Err(e),
-                            }
+            for n in start_line..end_line {
+                if n == existing_profile_line_numbers[counter] {
+                    updated_file_contents = match replace_config_value(file_contents, n, &config) {
+                        Ok(v) => v,
+                        Err(e) => return Err(e),
                     }
-                }
-            } else {
-                // Case where profile_name is at the beginning or at the middle of existing_profile_line_numbers
-                for n in existing_profile_line_numbers[counter]
-                    ..existing_profile_line_numbers[counter + 1]
-                {
-                    if n == existing_profile_line_numbers[counter] {
-                        updated_file_contents =
-                            match replace_config_value(file_contents, n, &config) {
-                                Ok(v) => v,
-                                Err(e) => return Err(e),
-                            }
-                    } else {
-                        updated_file_contents =
-                            match replace_config_value(&updated_file_contents.clone(), n, &config) {
-                                Ok(v) => v,
-                                Err(e) => return Err(e),
-                            }
-                    }
+                } else {
+                    updated_file_contents =
+                        match replace_config_value(&updated_file_contents.clone(), n, &config) {
+                            Ok(v) => v,
+                            Err(e) => return Err(e),
+                        }
                 }
             }
         }

--- a/src/utils/ini_config.rs
+++ b/src/utils/ini_config.rs
@@ -33,21 +33,16 @@ pub fn update_credentials_profile(
 ) -> Result<Vec<String>, CliError> {
     let (profile_start_line, profile_end_line) =
         find_line_numbers_for_profile(file_contents, profile_name);
-    let mut updated_file_contents: Vec<String> = Vec::new();
+    let mut updated_file_contents: Vec<String> = file_contents
+        .iter()
+        .map(|l| l.as_ref().to_string())
+        .collect();
     for n in profile_start_line..profile_end_line {
-        if n == profile_start_line {
-            updated_file_contents = match replace_credentials_value(file_contents, n, &credentials)
-            {
+        updated_file_contents =
+            match replace_credentials_value(&updated_file_contents.clone(), n, &credentials) {
                 Ok(v) => v,
                 Err(e) => return Err(e),
             }
-        } else {
-            updated_file_contents =
-                match replace_credentials_value(&updated_file_contents.clone(), n, &credentials) {
-                    Ok(v) => v,
-                    Err(e) => return Err(e),
-                }
-        }
     }
     Ok(updated_file_contents)
 }
@@ -59,20 +54,16 @@ pub fn update_config_profile<T: AsRef<str>>(
 ) -> Result<Vec<String>, CliError> {
     let (profile_start_line, profile_end_line) =
         find_line_numbers_for_profile(file_contents, profile_name);
-    let mut updated_file_contents: Vec<String> = Vec::new();
+    let mut updated_file_contents: Vec<String> = file_contents
+        .iter()
+        .map(|l| l.as_ref().to_string())
+        .collect();
     for n in profile_start_line..profile_end_line {
-        if n == profile_start_line {
-            updated_file_contents = match replace_config_value(file_contents, n, &config) {
+        updated_file_contents =
+            match replace_config_value(&updated_file_contents.clone(), n, &config) {
                 Ok(v) => v,
                 Err(e) => return Err(e),
             }
-        } else {
-            updated_file_contents =
-                match replace_config_value(&updated_file_contents.clone(), n, &config) {
-                    Ok(v) => v,
-                    Err(e) => return Err(e),
-                }
-        }
     }
     Ok(updated_file_contents)
 }
@@ -157,27 +148,6 @@ pub fn does_profile_name_exist(file_contents: &[impl AsRef<str>], profile_name: 
     }
     false
 }
-//
-// fn find_profile_line_numbers<T: AsRef<str>>(file_contents: &[T]) -> Option<Vec<usize>> {
-//     let mut counter = 0;
-//     let mut profile_counter;
-//     let line_array_len = file_contents.len();
-//     let mut profile_start_line_num_array: Vec<usize> = Vec::new();
-//     while counter < line_array_len {
-//         let line = file_contents[counter].as_ref().trim().to_string();
-//         if line.starts_with('[') && line.ends_with(']') {
-//             profile_counter = counter;
-//             // Collect line number of profile
-//             profile_start_line_num_array.push(profile_counter);
-//         }
-//         counter += 1;
-//     }
-//     if profile_start_line_num_array.is_empty() {
-//         None
-//     } else {
-//         Some(profile_start_line_num_array)
-//     }
-// }
 
 fn find_line_numbers_for_profile(
     file_contents: &[impl AsRef<str>],
@@ -228,23 +198,6 @@ fn find_line_numbers_for_profile(
 fn is_profile_header_line(line: &str) -> bool {
     PROFILE_HEADER_REGEX.is_match(line)
 }
-//
-// fn find_existing_profile_start<T: AsRef<str>>(file_contents: &[T], profile_name: &str) -> usize {
-//     let mut counter = 0;
-//     let line_array_len = file_contents.len();
-//
-//     while counter < line_array_len {
-//         let trimmed_line = file_contents[counter]
-//             .as_ref()
-//             .to_string()
-//             .replace('\n', "");
-//         if trimmed_line.eq(&format!("[{profile_name}]")) {
-//             return counter;
-//         }
-//         counter += 1;
-//     }
-//     counter
-// }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR contains a series of commits that make simplifications to the code for updating the config/credentials files.  Should be easier to maintain as a result, as well as significantly reducing the number of copy operations that are being made when updating the files.