### PR TITLE
fix: add protoc for aarch64 cross build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,15 @@ name = "momento-cli"
 version = "0.28.0"
 edition = "2021"
 
+[package.metadata.cross.target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "apt-get install -y unzip",
+    "curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip -o protoc.zip",
+    "unzip -o protoc.zip -d protoc",
+    "mv protoc/bin/* /usr/local/bin/",
+    "mv protoc/include/* /usr/local/include/"
+]
+
 [features]
 default = []
 login = []


### PR DESCRIPTION
this docker image uses x86_64 to cross compile to aarch64, even on
aarch64 hosts, so x64_64 is the right protoc version.

Scripts aren't conveniently on the build path or I would have invoked
the script. However, we need to remove this protoc dependency from our
client_protos package anyway so I'm not going to over-engineer this
