### PR TITLE
chore: update sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .idea/
+.vscode/
 client-cli.iml
 .DS_Store
 .vs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,11 +862,13 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711e204d396c31110ceb6c90bc0ebfa0317b27fd7c8a8d03f35ac79e8e07b7b8"
+checksum = "d01463318deb034af8364c79c4e41c211e2b327deeb1bdc86a857adec9829cf9"
 dependencies = [
  "chrono",
+ "h2",
+ "hyper",
  "jsonwebtoken",
  "log",
  "momento-protos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ predicates = "2.1.1"
 tempdir = "0.3.7"
 
 [dependencies.momento]
-version = "0.21"
+version = "0.22"
 
 [dependencies.clap]
 version = "4.1"

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -25,9 +25,10 @@ fn login_with_browser(action: LoginAction) -> EarlyOutActionResult {
                 log::debug!("opened browser to {}", open.url);
                 None
             }
-            Err(e) => Some(Err(MomentoError::ClientSdkError(format!(
-                "Unable to open browser: {e:?}"
-            )))),
+            Err(e) => Some(Err(MomentoError::ClientSdkError {
+                description: "Unable to open browser".into(),
+                source: momento::ErrorSource::Unknown(Box::new(e)),
+            })),
         },
         momento::auth::LoginAction::ShowMessage(message) => {
             console_info!("{}", message.text);
@@ -50,9 +51,10 @@ fn login_with_qr_code(action: LoginAction) -> EarlyOutActionResult {
                     console_info!("{}", image);
                     None
                 }
-                Err(e) => Some(Err(MomentoError::ClientSdkError(format!(
-                    "Unable to generate qr code: {e:?}"
-                )))),
+                Err(e) => Some(Err(MomentoError::ClientSdkError {
+                    description: "could not make qr code".into(),
+                    source: momento::ErrorSource::Unknown(Box::new(e)),
+                })),
             }
         }
         momento::auth::LoginAction::ShowMessage(message) => {

--- a/src/utils/client.rs
+++ b/src/utils/client.rs
@@ -15,11 +15,7 @@ pub async fn get_momento_client(
         endpoint,
     )
     .map_or_else(
-        |error| {
-            Err(CliError {
-                msg: error.to_string(),
-            })
-        },
+        |error| Err(Into::<CliError>::into(error)),
         |builder| Ok(builder.build()),
     )
 }
@@ -44,7 +40,5 @@ where
     log::debug!("{}", debug_note);
 
     let result = momento_interaction.await;
-    result.map_err(|error| CliError {
-        msg: error.to_string(),
-    })
+    result.map_err(Into::<CliError>::into)
 }

--- a/tests/momento_additional_profile_test.rs
+++ b/tests/momento_additional_profile_test.rs
@@ -22,7 +22,7 @@ mod tests {
             .assert()
             .failure()
             .stderr(
-                predicate::str::is_match("ERROR: error trying to connect: dns error:")
+                predicate::str::is_match("error trying to connect: dns error:")
                     .expect("Unable to create dns error predicate"),
             );
 


### PR DESCRIPTION
consume the latest sdk with the new error types. This also lets
`topic subscribe` do a little bit better with output when the
connection is interrupted without an error - whether due to
inactivity or a service deployment and h2 goaway.
