### PR TITLE
chore: generate zsh/bash completion scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd125be87bf4c255ebc50de0b7f4d2a6201e8ac3dc86e39c0ad081dc5e7236fe"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +981,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "configparser",
  "env_logger",

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::CommandFactory;
 use clap::Parser;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]
@@ -7,11 +8,11 @@ pub enum LoginMode {
 }
 
 #[derive(Debug, Parser)]
-#[clap(
+#[command(
     version,
     bin_name = "momento",
-    about = "CLI for Momento APIs",
-    name = "momento"
+    name = "momento",
+    about = "Command line tool for Momento Serverless Cache"
 )]
 pub struct Momento {
     #[arg(name = "verbose", global = true, long, help = "Log more information")]
@@ -28,6 +29,12 @@ pub struct Momento {
 
     #[command(subcommand)]
     pub command: Subcommand,
+}
+
+impl Momento {
+    pub fn meta_command() -> clap::Command {
+        Momento::command()
+    }
 }
 
 #[derive(Debug, Parser)]

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -62,3 +62,7 @@ default-features = false
 [dev-dependencies.uuid]
 version = "1.2.2"
 features = [ "v4",]
+
+[build-dependencies]
+momento-cli-opts = { path = "../momento-cli-opts" }
+clap_complete = { version = "4.1" }

--- a/momento/build.rs
+++ b/momento/build.rs
@@ -17,8 +17,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // and such.  cargo does not currently provide us an env var for target dir,
     // so we compute it.  (It happens to be 3 dirs up from OUT_DIR).
     let target_dir = Path::new(&out_dir).join("../../..");
-    generate_to(Zsh, &mut command, "mm", &target_dir)?;
-    generate_to(Bash, &mut command, "mm", &target_dir)?;
+    generate_to(Zsh, &mut command, "momento", &target_dir)?;
+    generate_to(Bash, &mut command, "momento", &target_dir)?;
 
     Ok(())
 }

--- a/momento/build.rs
+++ b/momento/build.rs
@@ -1,0 +1,24 @@
+use momento_cli_opts::Momento;
+
+use std::env;
+use std::error::Error;
+use std::path::Path;
+
+use clap_complete::generate_to;
+use clap_complete::shells::{Bash, Zsh};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut command = Momento::meta_command();
+
+    // OUT_DIR is a unique output dir for the crate, with a pseudo-random name.
+    let out_dir = env::var("OUT_DIR")?;
+    // we want to write the completion file to the "target dir", where the binary
+    // is written, so that it's easier to find it when we are creating installers
+    // and such.  cargo does not currently provide us an env var for target dir,
+    // so we compute it.  (It happens to be 3 dirs up from OUT_DIR).
+    let target_dir = Path::new(&out_dir).join("../../..");
+    generate_to(Zsh, &mut command, "mm", &target_dir)?;
+    generate_to(Bash, &mut command, "mm", &target_dir)?;
+
+    Ok(())
+}


### PR DESCRIPTION
In a subsequent commit we will need to package these in the appropriate places in the releases in order for them to work.