### PR TITLE
chore: re-word help messages for preview features

### DIFF
--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -52,18 +52,21 @@ pub enum Subcommand {
         #[command(subcommand)]
         operation: CacheCommand,
     },
-    /// Interact with topics
-    /// !!                            !!
-    /// !!       Preview feature      !!
-    /// !!  Your feedback is welcome  !!
-    /// !!                            !!
-    /// These commands requires a cache, which serves as a namespace
-    /// for your topics. If you haven't already, call `cache create`
-    /// to make one!
-    ///
-    /// To create a topic, subscribe to it.
-    /// To delete a topic, stop subscribing to it.
-    #[command(verbatim_doc_comment, hide = true)]
+    #[command(
+        hide = true,
+        about = "**PREVIEW** Interact with topics",
+        long_about = "Interact with topics
+!!                            !!
+!!       Preview feature      !!
+!!  Your feedback is welcome  !!
+!!                            !!
+These commands requires a cache, which serves as a namespace
+for your topics. If you haven't already, call `cache create`
+to make one!
+
+To create a topic, subscribe to it.
+To delete a topic, stop subscribing to it."
+    )]
     Topic {
         #[arg(
             long = "endpoint",
@@ -100,7 +103,7 @@ pub enum Subcommand {
         operation: SigningKeyCommand,
     },
     #[command(
-        about = "*Construction Zone* We're working on this! *Construction Zone* Log in to manage your Momento account",
+        about = "**PREVIEW** Log in to manage your Momento account",
         hide = true
     )]
     Login {


### PR DESCRIPTION
The zsh/bash completion is showing the hidden preview features
even though they don't show up in help.  Prior to this commit
the wording for the help message for the topics subcommand
looked really bad in zsh tab completion; this commit should
make it look more reasonable.
