### PR TITLE
feat: add new preview subcommand for beta features

### DIFF
--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -53,13 +53,8 @@ pub enum Subcommand {
         operation: CacheCommand,
     },
     #[command(
-        hide = true,
-        about = "**PREVIEW** Interact with topics",
+        about = "Interact with topics",
         before_help = "
-!!                            !!
-!!       Preview feature      !!
-!!  Your feedback is welcome  !!
-!!                            !!
 These commands requires a cache, which serves as a namespace
 for your topics. If you haven't already, call `cache create`
 to make one!
@@ -89,48 +84,10 @@ To delete a topic, stop subscribing to it."
         #[command(subcommand)]
         operation: AccountCommand,
     },
-    #[command(
-        hide = true,
-        about = "**PREVIEW** Manage signing keys",
-        before_help = "
-!!                                                                !!
-!!                        Preview feature                         !!
-!!   For more information, contact us at support@gomomento.com.   !!
-!!                                                                !!
-
-Signing keys can be used to generate pre-signed URLs that allow access to a value in the cache
-for a specified period of time.  The URLs can be distributed to browsers or devices to allow
-them to access the cache value without having access to a Momento auth token.
-    "
-    )]
-    SigningKey {
-        #[arg(
-            long = "endpoint",
-            short = 'e',
-            global = true,
-            help = "An explicit hostname to use; for example, cell-us-east-1-1.prod.a.momentohq.com"
-        )]
-        endpoint: Option<String>,
-
+    #[command(about = "**PREVIEW** features which are in beta. Feedback is welcome!")]
+    Preview {
         #[command(subcommand)]
-        operation: SigningKeyCommand,
-    },
-    #[command(
-        hide = true,
-        about = "**PREVIEW** Log in to manage your Momento account",
-        before_help = "
-!!                                                                !!
-!!                        Preview feature                         !!
-!!   For more information, contact us at support@gomomento.com.   !!
-!!                                                                !!
-
-This command will be used to log in to your Momento account and generate secure, time-limited
-tokens for accessing your Momento caches.
-"
-    )]
-    Login {
-        #[arg(value_enum, default_value = "browser")]
-        via: LoginMode,
+        operation: PreviewCommand,
     },
 }
 
@@ -163,6 +120,51 @@ pub enum AccountCommand {
     Signup {
         #[command(subcommand)]
         signup_operation: CloudSignupCommand,
+    },
+}
+
+#[derive(Debug, Parser)]
+pub enum PreviewCommand {
+    #[command(
+        about = "**PREVIEW** Manage signing keys",
+        before_help = "
+!!                                                                !!
+!!                        Preview feature                         !!
+!!   For more information, contact us at support@gomomento.com.   !!
+!!                                                                !!
+
+Signing keys can be used to generate pre-signed URLs that allow access to a value in the cache
+for a specified period of time.  The URLs can be distributed to browsers or devices to allow
+them to access the cache value without having access to a Momento auth token.
+    "
+    )]
+    SigningKey {
+        #[arg(
+            long = "endpoint",
+            short = 'e',
+            global = true,
+            help = "An explicit hostname to use; for example, cell-us-east-1-1.prod.a.momentohq.com"
+        )]
+        endpoint: Option<String>,
+
+        #[command(subcommand)]
+        operation: SigningKeyCommand,
+    },
+    #[command(
+        about = "**PREVIEW** Log in to manage your Momento account",
+        before_help = "
+!!                                                                !!
+!!                        Preview feature                         !!
+!!   For more information, contact us at support@gomomento.com.   !!
+!!                                                                !!
+
+This command will be used to log in to your Momento account and generate secure, time-limited
+tokens for accessing your Momento caches.
+"
+    )]
+    Login {
+        #[arg(value_enum, default_value = "browser")]
+        via: LoginMode,
     },
 }
 

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -168,51 +168,55 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 }
             },
         },
-        momento_cli_opts::Subcommand::SigningKey {
-            endpoint,
-            operation,
-        } => match operation {
-            momento_cli_opts::SigningKeyCommand::Create { ttl_minutes } => {
-                let (creds, _config) = get_creds_and_config(&args.profile).await?;
-                commands::signingkey::signingkey_cli::create_signing_key(
-                    ttl_minutes,
-                    creds.token,
-                    endpoint,
-                )
-                .await?;
-            }
-            momento_cli_opts::SigningKeyCommand::Revoke { key_id } => {
-                let (creds, _config) = get_creds_and_config(&args.profile).await?;
-                commands::signingkey::signingkey_cli::revoke_signing_key(
-                    key_id.clone(),
-                    creds.token,
-                    endpoint,
-                )
-                .await?;
-                debug!("revoked signing key {}", key_id)
-            }
-            momento_cli_opts::SigningKeyCommand::List {} => {
-                let (creds, _config) = get_creds_and_config(&args.profile).await?;
-                commands::signingkey::signingkey_cli::list_signing_keys(creds.token, endpoint)
-                    .await?
-            }
-        },
-        momento_cli_opts::Subcommand::Login { via } => match commands::login::login(via).await {
-            Ok(credentials) => {
-                let session_token = credentials.token();
-                let session_duration = credentials.valid_for();
-                debug!("{session_token}");
-                clobber_session_token(
-                    Some(session_token.to_string()),
-                    session_duration.as_secs() as u32,
-                )
-                .await?;
-                console_info!("Login valid for {}m", session_duration.as_secs() / 60);
-            }
-            Err(auth_error) => {
-                return Err(CliError {
-                    msg: format!("auth error: {auth_error:?}"),
-                })
+        momento_cli_opts::Subcommand::Preview { operation } => match operation {
+            momento_cli_opts::PreviewCommand::SigningKey {
+                endpoint,
+                operation,
+            } => match operation {
+                momento_cli_opts::SigningKeyCommand::Create { ttl_minutes } => {
+                    let (creds, _config) = get_creds_and_config(&args.profile).await?;
+                    commands::signingkey::signingkey_cli::create_signing_key(
+                        ttl_minutes,
+                        creds.token,
+                        endpoint,
+                    )
+                    .await?;
+                }
+                momento_cli_opts::SigningKeyCommand::Revoke { key_id } => {
+                    let (creds, _config) = get_creds_and_config(&args.profile).await?;
+                    commands::signingkey::signingkey_cli::revoke_signing_key(
+                        key_id.clone(),
+                        creds.token,
+                        endpoint,
+                    )
+                    .await?;
+                    debug!("revoked signing key {}", key_id)
+                }
+                momento_cli_opts::SigningKeyCommand::List {} => {
+                    let (creds, _config) = get_creds_and_config(&args.profile).await?;
+                    commands::signingkey::signingkey_cli::list_signing_keys(creds.token, endpoint)
+                        .await?
+                }
+            },
+            momento_cli_opts::PreviewCommand::Login { via } => {
+                match commands::login::login(via).await {
+                    Ok(credentials) => {
+                        let session_token = credentials.token();
+                        let session_duration = credentials.valid_for();
+                        debug!("{session_token}");
+                        clobber_session_token(
+                            Some(session_token.to_string()),
+                            session_duration.as_secs() as u32,
+                        )
+                        .await?;
+                        console_info!("Login valid for {}m", session_duration.as_secs() / 60);
+                    }
+                    Err(auth_error) => {
+                        return Err(CliError {
+                            msg: format!("auth error: {auth_error:?}"),
+                        })
+                    }
+                }
             }
         },
     }

--- a/momento/tests/momento_additional_profile_test.rs
+++ b/momento/tests/momento_additional_profile_test.rs
@@ -103,8 +103,8 @@ mod tests {
             vec!["configure", "--profile", profile_name],
             vec!["--profile", profile_name, "configure"],
             // signing-key subcommand
-            vec!["signing-key", "list", "--profile", profile_name],
-            vec!["signing-key", "--profile", profile_name, "list"],
+            vec!["preview", "signing-key", "list", "--profile", profile_name],
+            vec!["preview", "signing-key", "--profile", profile_name, "list"],
             vec!["--profile", profile_name, "signing-key", "list"],
             // account subcommand
             vec!["account", "signup", "--profile", profile_name, "help"],

--- a/momento/tests/momento_additional_profile_test.rs
+++ b/momento/tests/momento_additional_profile_test.rs
@@ -105,7 +105,7 @@ mod tests {
             // signing-key subcommand
             vec!["preview", "signing-key", "list", "--profile", profile_name],
             vec!["preview", "signing-key", "--profile", profile_name, "list"],
-            vec!["--profile", profile_name, "signing-key", "list"],
+            vec!["--profile", profile_name, "preview", "signing-key", "list"],
             // account subcommand
             vec!["account", "signup", "--profile", profile_name, "help"],
             vec!["account", "--profile", profile_name, "signup", "help"],


### PR DESCRIPTION
creates a new subcommand `preview` to put features that are still being worked on. It is not hidden, since we are clearly marking every command under `preview` as not fully productionized. 

- `**Preview**` text removed from topics command description
- moved `singing-keys` and `login` subcommands under `preview` functionality