### PR TITLE
feat: add preview command to generate api tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,10 +958,11 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "468c1703e05eed42b1efefb1cb4170eb38551146aadbb90e7ad84d9e1bf1ddc0"
+checksum = "aa3db46d01a8869e239d6ff7c758bc2541cc5a28718dac137add2b4d98ae90e8"
 dependencies = [
+ "base64 0.21.0",
  "h2",
  "hyper",
  "jsonwebtoken",
@@ -1013,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.43.0"
+version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc35fd8627a1baffd01fb407dd754abbcc5877809440cf88834060dba73f5d58"
+checksum = "da01852fd00013f08ee01227628236dddee61d902b2e181887400cb5bdecb2df"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,20 +414,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "duration-str"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94be4825ff6a563f1bfbdb786ae10c687333c7524fade954e2271170e7f7e6d"
-dependencies = [
- "chrono",
- "nom",
- "rust_decimal",
- "serde",
- "thiserror",
- "time 0.3.17",
-]
 
 [[package]]
 name = "either"
@@ -965,12 +945,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,9 +985,9 @@ dependencies = [
  "clap_complete",
  "colored",
  "configparser",
- "duration-str",
  "env_logger",
  "home",
+ "humantime",
  "lazy_static",
  "log",
  "momento",
@@ -1061,16 +1035,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nom8"
@@ -1605,16 +1569,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13cf35f7140155d02ba4ec3294373d513a3c7baa8364c162b030e33c61520a8"
-dependencies = [
- "arrayvec",
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +420,20 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "duration-str"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94be4825ff6a563f1bfbdb786ae10c687333c7524fade954e2271170e7f7e6d"
+dependencies = [
+ "chrono",
+ "nom",
+ "rust_decimal",
+ "serde",
+ "thiserror",
+ "time 0.3.17",
+]
 
 [[package]]
 name = "either"
@@ -945,6 +965,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1011,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "configparser",
+ "duration-str",
  "env_logger",
  "home",
  "lazy_static",
@@ -1034,6 +1061,16 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nom8"
@@ -1568,6 +1605,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13cf35f7140155d02ba4ec3294373d513a3c7baa8364c162b030e33c61520a8"
+dependencies = [
+ "arrayvec",
+ "num-traits",
 ]
 
 [[package]]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -188,7 +188,7 @@ Either `--valid-for_seconds` or `--never` must be specified.
         #[arg(
             long,
             short,
-            help = "Specify how long until the token expires. Ex. 1d, 10min, 2mon"
+            help = "Specify how long until the token expires. Ex. 1d, 10m, 2M"
         )]
         valid_for: Option<String>,
         #[arg(long, help = "Generate a token that never expires")]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -84,7 +84,10 @@ To delete a topic, stop subscribing to it."
         #[command(subcommand)]
         operation: AccountCommand,
     },
-    #[command(about = "**PREVIEW** features which are in beta. Feedback is welcome!")]
+    #[command(
+        about = "**PREVIEW** features which are in beta. Feedback is welcome!",
+        hide = true
+    )]
     Preview {
         #[command(subcommand)]
         operation: PreviewCommand,

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -167,6 +167,11 @@ tokens for accessing your Momento caches.
         via: LoginMode,
     },
     #[command(
+        group(
+            clap::ArgGroup::new("generate-token")
+                .required(true)
+                .args(&["valid_for_seconds", "never"]),
+        ),
         about = "**PREVIEW** Generate an api token for Momento",
         before_help = "
 !!                                                                !!

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -179,16 +179,16 @@ tokens for accessing your Momento caches.
 !!   For more information, contact us at support@gomomento.com.   !!
 !!                                                                !!
 
-This command will be used to generate api tokens to use with Momento. If `--never` is specified,
+This command will be used to generate api tokens to use with Momento. If `--never-expire` is specified,
 then the generated token will never expire. Else, it will expire after the specified number of seconds.
-Either `--valid-for_seconds` or `--never` must be specified.
+Either `--valid-for` or `--never-expire` must be specified.
 "
     )]
     GenerateToken {
         #[arg(
             long,
             short,
-            help = "Specify how long until the token expires. Ex. 1d, 10m, 2M"
+            help = "Specify how long until the token expires. ex. 1d, 10m, 2M"
         )]
         valid_for: Option<String>,
         #[arg(long, help = "Generate a token that never expires")]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -166,6 +166,32 @@ tokens for accessing your Momento caches.
         #[arg(value_enum, default_value = "browser")]
         via: LoginMode,
     },
+    #[command(
+        about = "**PREVIEW** Generate an api token for Momento",
+        before_help = "
+!!                                                                !!
+!!                        Preview feature                         !!
+!!   For more information, contact us at support@gomomento.com.   !!
+!!                                                                !!
+
+This command will be used to generate api tokens to use with Momento. If `--never` is specified,
+then the generated token will never expire. Else, it will expire after the specified number of seconds.
+Either `--valid-for_seconds` or `--never` must be specified.
+"
+    )]
+    GenerateToken {
+        #[arg(long, short)]
+        valid_for_seconds: Option<u32>,
+        #[arg(long, help = "Generate a token that never expires")]
+        never: bool,
+        #[arg(
+            long = "endpoint",
+            short = 'e',
+            global = true,
+            help = "An explicit hostname to use; for example, cell-us-east-1-1.prod.a.momentohq.com"
+        )]
+        endpoint: Option<String>,
+    },
 }
 
 #[derive(Debug, Parser)]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -170,7 +170,7 @@ tokens for accessing your Momento caches.
         group(
             clap::ArgGroup::new("generate-token")
                 .required(true)
-                .args(&["valid_for_seconds", "never"]),
+                .args(&["valid_for", "never_expire"]),
         ),
         about = "**PREVIEW** Generate an api token for Momento",
         before_help = "
@@ -185,10 +185,14 @@ Either `--valid-for_seconds` or `--never` must be specified.
 "
     )]
     GenerateToken {
-        #[arg(long, short)]
-        valid_for_seconds: Option<u32>,
+        #[arg(
+            long,
+            short,
+            help = "Specify how long until the token expires. Ex. 1d, 10min, 2mon"
+        )]
+        valid_for: Option<String>,
         #[arg(long, help = "Generate a token that never expires")]
-        never: bool,
+        never_expire: bool,
         #[arg(
             long = "endpoint",
             short = 'e',

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -17,6 +17,7 @@ configparser = "3.0.0"
 regex = "1"
 qrcode = "0.12.0"
 webbrowser = "^0.8.4"
+duration-str = "0.5.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -17,7 +17,7 @@ configparser = "3.0.0"
 regex = "1"
 qrcode = "0.12.0"
 webbrowser = "^0.8.4"
-duration-str = "0.5.0"
+humantime = "2.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -27,7 +27,7 @@ tempdir = "0.3.7"
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-version = "0.24.0"
+version = "0.26.2"
 
 [dependencies.clap]
 version = "4.1"

--- a/momento/src/commands/mod.rs
+++ b/momento/src/commands/mod.rs
@@ -3,5 +3,6 @@ pub mod cache;
 pub mod configure;
 pub mod login;
 pub mod signingkey;
+pub mod tokens;
 
 pub mod topic;

--- a/momento/src/commands/tokens/mod.rs
+++ b/momento/src/commands/tokens/mod.rs
@@ -1,0 +1,18 @@
+use momento::requests::generate_api_token_request::TokenExpiry;
+
+use crate::{
+    error::CliError,
+    utils::client::{get_momento_client, interact_with_momento, print_whatever_this_is_as_json},
+};
+
+pub async fn generate_api_token(
+    auth_token: String,
+    endpoint: Option<String>,
+    expiry: TokenExpiry,
+) -> Result<(), CliError> {
+    let mut client = get_momento_client(auth_token, endpoint).await?;
+    print_whatever_this_is_as_json(
+        &interact_with_momento("generating...", client.generate_api_token(expiry)).await?,
+    );
+    Ok(())
+}

--- a/momento/src/commands/tokens/mod.rs
+++ b/momento/src/commands/tokens/mod.rs
@@ -1,4 +1,3 @@
-use duration_str::parse;
 use momento::requests::generate_api_token_request::TokenExpiry;
 
 use crate::{
@@ -15,20 +14,20 @@ pub async fn generate_api_token(
     let expiry = if never_expire {
         TokenExpiry::Never {}
     } else {
-        let seconds = parse(
-            valid_for
-                .expect("oneof --valid-for, or --never-expire, must be set")
-                .as_str(),
-        )
-        .expect("unable to parse valid_for duration")
-        .as_secs();
+        let seconds = valid_for
+            .expect("oneof --valid-for, or --never-expire, must be set")
+            .as_str()
+            .parse::<humantime::Duration>()
+            .expect("unable to parse valid_for duration")
+            .as_secs();
         TokenExpiry::Expires {
             valid_for_seconds: seconds as u32,
         }
     };
     let mut client = get_momento_client(auth_token, endpoint).await?;
     print_whatever_this_is_as_json(
-        &interact_with_momento("generating...", client.generate_api_token(expiry)).await?,
+        &interact_with_momento("generating api token...", client.generate_api_token(expiry))
+            .await?,
     );
     Ok(())
 }

--- a/momento/src/commands/tokens/mod.rs
+++ b/momento/src/commands/tokens/mod.rs
@@ -18,7 +18,7 @@ pub async fn generate_api_token(
             .expect("oneof --valid-for, or --never-expire, must be set")
             .as_str()
             .parse::<humantime::Duration>()
-            .expect("unable to parse valid_for duration")
+            .expect("unable to parse valid-for duration")
             .as_secs();
         TokenExpiry::Expires {
             valid_for_seconds: seconds as u32,

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -5,7 +5,6 @@ use commands::topic::print_subscription;
 use env_logger::Env;
 use error::CliError;
 use log::{debug, error, LevelFilter};
-use momento::requests::generate_api_token_request::TokenExpiry;
 use momento::MomentoError;
 use utils::{console::output_info, user::get_creds_and_config};
 
@@ -220,20 +219,18 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 }
             }
             momento_cli_opts::PreviewCommand::GenerateToken {
-                valid_for_seconds,
-                never,
+                valid_for,
+                never_expire,
                 endpoint,
             } => {
-                let expiry = if never {
-                    TokenExpiry::Never {}
-                } else {
-                    TokenExpiry::Expires {
-                        valid_for_seconds: valid_for_seconds
-                            .expect("oneof valid_for_seconds, or never, must be set"),
-                    }
-                };
                 let (creds, _config) = get_creds_and_config(&args.profile).await?;
-                commands::tokens::generate_api_token(creds.token, endpoint, expiry).await?;
+                commands::tokens::generate_api_token(
+                    creds.token,
+                    endpoint,
+                    never_expire,
+                    valid_for,
+                )
+                .await?;
             }
         },
     }

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -5,6 +5,7 @@ use commands::topic::print_subscription;
 use env_logger::Env;
 use error::CliError;
 use log::{debug, error, LevelFilter};
+use momento::requests::generate_api_token_request::TokenExpiry;
 use momento::MomentoError;
 use utils::{console::output_info, user::get_creds_and_config};
 
@@ -217,6 +218,22 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         })
                     }
                 }
+            }
+            momento_cli_opts::PreviewCommand::GenerateToken {
+                valid_for_seconds,
+                never,
+                endpoint,
+            } => {
+                let expiry = if never {
+                    TokenExpiry::Never {}
+                } else {
+                    TokenExpiry::Expires {
+                        valid_for_seconds: valid_for_seconds
+                            .expect("oneof valid_for_seconds, or never, must be set"),
+                    }
+                };
+                let (creds, _config) = get_creds_and_config(&args.profile).await?;
+                commands::tokens::generate_api_token(creds.token, endpoint, expiry).await?;
             }
         },
     }


### PR DESCRIPTION
`momento preview generate-token --never-expire --profile alpha`

```
{
  "api_token": "<token>",
  "refresh_token": "",
  "valid_until": {
    "secs_since_epoch": 1678213596,
    "nanos_since_epoch": 0
  }
}
```

Since this command is in preview, only engineers who have internal tokens will be able to use it.

<img width="693" alt="Screen Shot 2023-03-07 at 3 03 11 PM" src="https://user-images.githubusercontent.com/11823378/223574093-4285163a-f6b1-41d8-9b96-29307fbea00e.png">


<img width="814" alt="Screen Shot 2023-03-07 at 3 06 06 PM" src="https://user-images.githubusercontent.com/11823378/223574416-831f4ed2-f3ac-475a-8171-9ca02835ad85.png">


closes https://github.com/momentohq/momento-cli/issues/272