### PR TITLE
chore: Add eu-west-1 to list of supported regions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,7 +13,7 @@ Linux のインストールマニュアルは[こちら](https://github.com/mome
 brew tap momentohq/tap
 brew install momento-cli
 
-# サインアップ [available regions are us-west-2, us-east-1, ap-south-1, ap-northeast-1]
+# サインアップ [available regions are us-west-2, us-east-1, ap-south-1, ap-northeast-1, eu-west-1]
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
 # 上記のメールアドレスに送付されたトークンとデフォルトのキャッシュ名とTTLであなたのアカウントコンフィグ

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ the appropriate installation steps above.
 
 ```
 # Sign up
-## AWS [available regions are us-west-2, us-east-1, ap-south-1, ap-northeast-1]
+## AWS [available regions are us-west-2, us-east-1, ap-south-1, ap-northeast-1, eu-west-1]
 momento account signup aws --email <TYPE_YOUR_EMAIL_HERE> --region <TYPE_DESIRED_REGION>
 
 ## GCP [available regions are us-east1, asia-northeast1]

--- a/README.pt.md
+++ b/README.pt.md
@@ -9,7 +9,7 @@ Japonês: [日本語](README.ja.md)
 brew tap momentohq/tap
 brew install momento-cli
 
-## AWS [regiões disponíveis são us-west-2, us-east-1, ap-south-1, ap-northeast-1]
+## AWS [regiões disponíveis são us-west-2, us-east-1, ap-south-1, ap-northeast-1, eu-west-1]
 momento account signup aws --email <insira_seu_email_aqui> --region <regiao_desejada>
 
 ## GCP [regiões disponíveis são us-east1, ap-northeast1]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -222,7 +222,7 @@ pub enum CloudSignupCommand {
         #[arg(
             long,
             short,
-            value_name = "us-west-2, us-east-1, ap-northeast-1, ap-south-1"
+            value_name = "us-west-2, us-east-1, ap-northeast-1, ap-south-1, eu-west-1"
         )]
         region: String,
     },


### PR DESCRIPTION
Add eu-west-1 (Ireland) to the list of supported regions for the Momento Cli.