### PR TITLE
chore: Update sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.1.0"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7283377d6bbb0732d17f9341983965d823c1d9530a53a29bb28a04cc4086b013"
 dependencies = [
  "base64 0.21.0",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -262,7 +262,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -363,7 +363,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -380,7 +380,7 @@ checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -510,42 +510,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.26"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.26"
+name = "futures-executor"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
-
-[[package]]
-name = "futures-task"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
-
-[[package]]
-name = "futures-util"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -958,11 +1008,10 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa3db46d01a8869e239d6ff7c758bc2541cc5a28718dac137add2b4d98ae90e8"
+version = "0.1.0"
 dependencies = [
  "base64 0.21.0",
+ "futures",
  "h2",
  "hyper",
  "jsonwebtoken",
@@ -986,6 +1035,7 @@ dependencies = [
  "colored",
  "configparser",
  "env_logger",
+ "futures",
  "home",
  "humantime",
  "lazy_static",
@@ -1221,7 +1271,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1279,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1291,7 +1341,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -1308,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1342,7 +1392,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.107",
  "tempfile",
  "which",
 ]
@@ -1357,7 +1407,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1382,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -1710,7 +1760,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1824,6 +1874,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,7 +1946,7 @@ checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1989,7 +2050,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2108,7 +2169,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2183,7 +2244,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2365,7 +2426,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -2399,7 +2460,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -28,8 +28,7 @@ tempdir = "0.3.7"
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-#version = "0.26.2"
-path = "../../client-sdk-rust"
+version = "0.29.0"
 
 [dependencies.futures]
 version = "0.3.28"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -28,7 +28,11 @@ tempdir = "0.3.7"
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-version = "0.26.2"
+#version = "0.26.2"
+path = "../../client-sdk-rust"
+
+[dependencies.futures]
+version = "0.3.28"
 
 [dependencies.clap]
 version = "4.1"

--- a/momento/src/commands/cache/cache_cli.rs
+++ b/momento/src/commands/cache/cache_cli.rs
@@ -88,17 +88,14 @@ pub async fn get(
     let mut client = get_momento_client(auth_token, endpoint).await?;
 
     let response = interact_with_momento("getting...", client.get(&cache_name, key)).await?;
-    match response.result {
-        momento::response::MomentoGetStatus::HIT => {
-            console_data!("{}", response.as_string())
+    match response {
+        momento::response::Get::Hit { value} => {
+            let value: String = value.try_into()?;
+            console_data!("{}", value);
         }
-        momento::response::MomentoGetStatus::MISS => {
+        momento::response::Get::Miss => {
             debug!("cache miss");
             exit(1)
-        }
-        momento::response::MomentoGetStatus::ERROR => {
-            debug!("something terrible happened with the wire protocol");
-            exit(13)
         }
     };
     Ok(())

--- a/momento/src/commands/cache/cache_cli.rs
+++ b/momento/src/commands/cache/cache_cli.rs
@@ -89,7 +89,7 @@ pub async fn get(
 
     let response = interact_with_momento("getting...", client.get(&cache_name, key)).await?;
     match response {
-        momento::response::Get::Hit { value} => {
+        momento::response::Get::Hit { value } => {
             let value: String = value.try_into()?;
             console_data!("{}", value);
         }

--- a/momento/src/commands/topic/mod.rs
+++ b/momento/src/commands/topic/mod.rs
@@ -1,9 +1,10 @@
+use futures::StreamExt;
 use momento::{preview::topics::Subscription, MomentoResult};
 
 use crate::utils::console::console_data;
 
 pub async fn print_subscription(mut subscription: Subscription) -> MomentoResult<()> {
-    while let Some(item) = subscription.item().await? {
+    while let Some(item) = subscription.next().await {
         match item {
             momento::preview::topics::SubscriptionItem::Value(value) => match value.kind {
                 momento::preview::topics::ValueKind::Text(text) => console_data!("{text}"),

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -119,14 +119,16 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
             operation,
         } => {
             let (creds, config) = get_creds_and_config(&args.profile).await?;
-            let mut credential_provider_builder = CredentialProviderBuilder::from_string(creds.token);
-            if let Some(endpoint_override)  = endpoint {
-                credential_provider_builder = credential_provider_builder.with_momento_endpoint(endpoint_override)
+            let mut credential_provider_builder =
+                CredentialProviderBuilder::from_string(creds.token);
+            if let Some(endpoint_override) = endpoint {
+                credential_provider_builder =
+                    credential_provider_builder.with_momento_endpoint(endpoint_override)
             }
             let credential_provider = credential_provider_builder.build()?;
 
             let mut client =
-                momento::preview::topics::TopicClient::connect(credential_provider,  Some("cli"))
+                momento::preview::topics::TopicClient::connect(credential_provider, Some("cli"))
                     .map_err(Into::<CliError>::into)?;
             match operation {
                 momento_cli_opts::TopicCommand::Publish {
@@ -142,14 +144,15 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 }
                 momento_cli_opts::TopicCommand::Subscribe { cache_name, topic } => {
                     let cache_name = cache_name.unwrap_or(config.cache);
-                    let subscription = client
-                        .subscribe(cache_name, topic, None)
-                        .await
-                        .map_err(|e| CliError {
-                            msg: format!(
-                                "the subscription ended without receiving any values: {e:?}"
-                            ),
-                        })?;
+                    let subscription =
+                        client
+                            .subscribe(cache_name, topic, None)
+                            .await
+                            .map_err(|e| CliError {
+                                msg: format!(
+                                    "the subscription ended without receiving any values: {e:?}"
+                                ),
+                            })?;
                     match print_subscription(subscription).await {
                         Ok(_) => console_info!("The subscription ended"),
                         Err(e) => match e {

--- a/momento/src/utils/client.rs
+++ b/momento/src/utils/client.rs
@@ -1,6 +1,8 @@
 use std::{future::Future, time::Duration};
 
-use momento::{CredentialProviderBuilder, response::MomentoError, SimpleCacheClient, SimpleCacheClientBuilder};
+use momento::{
+    response::MomentoError, CredentialProviderBuilder, SimpleCacheClient, SimpleCacheClientBuilder,
+};
 
 use crate::{error::CliError, utils::console::console_data};
 
@@ -10,7 +12,8 @@ pub async fn get_momento_client(
 ) -> Result<SimpleCacheClient, CliError> {
     let mut credential_provider_builder = CredentialProviderBuilder::from_string(auth_token);
     if let Some(momento_override) = endpoint {
-        credential_provider_builder = credential_provider_builder.with_momento_endpoint(momento_override);
+        credential_provider_builder =
+            credential_provider_builder.with_momento_endpoint(momento_override);
     }
     let credential_provider = credential_provider_builder.build()?;
     SimpleCacheClientBuilder::new_with_explicit_agent_name(

--- a/momento/src/utils/client.rs
+++ b/momento/src/utils/client.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, time::Duration};
 
-use momento::{response::MomentoError, SimpleCacheClient, SimpleCacheClientBuilder};
+use momento::{CredentialProviderBuilder, response::MomentoError, SimpleCacheClient, SimpleCacheClientBuilder};
 
 use crate::{error::CliError, utils::console::console_data};
 
@@ -8,11 +8,15 @@ pub async fn get_momento_client(
     auth_token: String,
     endpoint: Option<String>,
 ) -> Result<SimpleCacheClient, CliError> {
+    let mut credential_provider_builder = CredentialProviderBuilder::from_string(auth_token);
+    if let Some(momento_override) = endpoint {
+        credential_provider_builder = credential_provider_builder.with_momento_endpoint(momento_override);
+    }
+    let credential_provider = credential_provider_builder.build()?;
     SimpleCacheClientBuilder::new_with_explicit_agent_name(
-        auth_token,
+        credential_provider,
         Duration::from_secs(120),
         "cli",
-        endpoint,
     )
     .map_or_else(
         |error| Err(Into::<CliError>::into(error)),


### PR DESCRIPTION
Bump Rust SDK version to 0.29.0. This supports tokens generated from the console so all the integration tests should pass again! :tada:
