### PR TITLE
feat: add support for deleting an item from cli

### DIFF
--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -359,6 +359,35 @@ clap::ArgGroup::new("cache-name")
         #[arg(long = "key", value_name = "KEY")]
         key_flag: Option<String>,
     },
+
+    #[command(
+    about = "Delete an item from the cache",
+    group(
+    clap::ArgGroup::new("cache-key")
+    .required(true)
+    .args(["key", "key_flag"]),
+    ),
+    group(
+    clap::ArgGroup::new("cache-name")
+    .args(["cache_name", "cache_name_flag_for_backward_compatibility"]),
+    ),
+    )]
+    DeleteItem {
+        #[arg(
+        long = "cache",
+        help = "Name of the cache you want to use. If not provided, your profile's default cache is used.",
+        value_name = "CACHE"
+        )]
+        cache_name: Option<String>,
+        #[arg(long = "name", value_name = "CACHE")]
+        cache_name_flag_for_backward_compatibility: Option<String>,
+
+        // TODO: Add support for non-string key-value
+        #[arg(help = "Cache key to delete")]
+        key: Option<String>,
+        #[arg(long = "key", value_name = "KEY")]
+        key_flag: Option<String>,
+    },
 }
 
 #[derive(Debug, Parser)]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -374,9 +374,9 @@ clap::ArgGroup::new("cache-name")
     )]
     DeleteItem {
         #[arg(
-        long = "cache",
-        help = "Name of the cache you want to use. If not provided, your profile's default cache is used.",
-        value_name = "CACHE"
+            long = "cache",
+            help = "Name of the cache you want to use. If not provided, your profile's default cache is used.",
+            value_name = "CACHE"
         )]
         cache_name: Option<String>,
         #[arg(long = "name", value_name = "CACHE")]

--- a/momento/src/commands/cache/cache_cli.rs
+++ b/momento/src/commands/cache/cache_cli.rs
@@ -111,13 +111,7 @@ pub async fn delete_key(
 
     let mut client = get_momento_client(auth_token, endpoint).await?;
 
-    interact_with_momento(
-            "deleting...",
-            client.delete(
-                &cache_name,
-                key
-            ),
-        )
+    interact_with_momento("deleting...", client.delete(&cache_name, key))
         .await
         .map(|_| ())
 }

--- a/momento/src/commands/cache/cache_cli.rs
+++ b/momento/src/commands/cache/cache_cli.rs
@@ -100,3 +100,24 @@ pub async fn get(
     };
     Ok(())
 }
+
+pub async fn delete_key(
+    cache_name: String,
+    auth_token: String,
+    key: String,
+    endpoint: Option<String>,
+) -> Result<(), CliError> {
+    debug!("deleting key: {} from cache: {}", key, cache_name);
+
+    let mut client = get_momento_client(auth_token, endpoint).await?;
+
+    interact_with_momento(
+            "deleting...",
+            client.delete(
+                &cache_name,
+                key
+            ),
+        )
+        .await
+        .map(|_| ())
+}

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -113,6 +113,26 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 )
                 .await?;
             }
+            momento_cli_opts::CacheCommand::DeleteItem {
+                cache_name,
+                cache_name_flag_for_backward_compatibility,
+                key,
+                key_flag,
+            } => {
+                let (creds, config) = get_creds_and_config(&args.profile).await?;
+                let key = key
+                    .or(key_flag)
+                    .expect("The argument group guarantees 1 or the other");
+                commands::cache::cache_cli::delete_key(
+                    cache_name
+                        .or(cache_name_flag_for_backward_compatibility)
+                        .unwrap_or(config.cache),
+                    creds.token,
+                    key,
+                    endpoint,
+                )
+                    .await?;
+            }
         },
         momento_cli_opts::Subcommand::Topic {
             endpoint,

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -131,7 +131,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                     key,
                     endpoint,
                 )
-                    .await?;
+                .await?;
             }
         },
         momento_cli_opts::Subcommand::Topic {

--- a/momento/tests/momento_additional_profile_test.rs
+++ b/momento/tests/momento_additional_profile_test.rs
@@ -73,9 +73,16 @@ mod tests {
 
     async fn momento_cache_delete_key_with_profile(profile_name: &str) {
         let mut cmd = Command::cargo_bin("momento").unwrap();
-        cmd.args(["cache", "delete-item", "--key", "key", "--profile", profile_name])
-            .assert()
-            .success();
+        cmd.args([
+            "cache",
+            "delete-item",
+            "--key",
+            "key",
+            "--profile",
+            profile_name,
+        ])
+        .assert()
+        .success();
     }
 
     async fn momento_cache_list_with_profile(profile_name: &str, cache_name: &str) {

--- a/momento/tests/momento_additional_profile_test.rs
+++ b/momento/tests/momento_additional_profile_test.rs
@@ -71,6 +71,13 @@ mod tests {
             .stdout("value\n");
     }
 
+    async fn momento_cache_delete_key_with_profile(profile_name: &str) {
+        let mut cmd = Command::cargo_bin("momento").unwrap();
+        cmd.args(["cache", "delete-item", "--key", "key", "--profile", profile_name])
+            .assert()
+            .success();
+    }
+
     async fn momento_cache_list_with_profile(profile_name: &str, cache_name: &str) {
         let mut cmd = Command::cargo_bin("momento").unwrap();
         cmd.args(["cache", "list", "--profile", profile_name])
@@ -126,6 +133,7 @@ mod tests {
 
         momento_configure_profiles(&test_auth_token, &test_run_id).await;
         momento_cache_create_with_profile(&test_run_id, &test_run_id).await;
+        momento_cache_delete_key_with_profile(&test_run_id).await;
         momento_cache_set_with_profile(&test_run_id).await;
         momento_cache_get_with_profile(&test_run_id).await;
         momento_cache_list_with_profile(&test_run_id, &test_run_id).await;

--- a/momento/tests/momento_additional_profile_test.rs
+++ b/momento/tests/momento_additional_profile_test.rs
@@ -133,9 +133,9 @@ mod tests {
 
         momento_configure_profiles(&test_auth_token, &test_run_id).await;
         momento_cache_create_with_profile(&test_run_id, &test_run_id).await;
-        momento_cache_delete_key_with_profile(&test_run_id).await;
         momento_cache_set_with_profile(&test_run_id).await;
         momento_cache_get_with_profile(&test_run_id).await;
+        momento_cache_delete_key_with_profile(&test_run_id).await;
         momento_cache_list_with_profile(&test_run_id, &test_run_id).await;
         momento_cache_delete_with_profile(&test_run_id, &test_run_id).await;
         test_profile_allowed_in_any_position(&test_run_id).await;


### PR DESCRIPTION
Added support to delete an item for a cache. Since we already had ```delete``` as a cache subcommand to delete the cache, I went with ```delete-item``` for this one. Let me know if you have better suggestions.

How was this change tested?

- Manually ran ```./target/debug/momento cache delete-item``` for a key I had inserted and verified it got deleted from the cache. A non-existent key doesn't throw an error.
- Added a test case for command verification similar to other commands.