### PR TITLE
feat: fetch metrics for the dynamo and elasticache resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5458d9d1a587efaf5091602c59d299696a3877a439c8f6d461a2d3cce11df87a"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +937,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1443,6 +1462,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,6 +1693,7 @@ dependencies = [
  "governor",
  "home",
  "humantime",
+ "indicatif",
  "lazy_static",
  "log",
  "momento",
@@ -1808,6 +1841,12 @@ dependencies = [
  "hermit-abi 0.2.6",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "log",
  "momento",
  "momento-cli-opts",
+ "phf",
  "predicates",
  "qrcode",
  "regex",
@@ -1887,6 +1888,48 @@ checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap 1.9.2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2534,6 +2577,12 @@ dependencies = [
  "thiserror",
  "time 0.3.17",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -23,6 +23,7 @@ aws-config = "1.1.8"
 aws-sdk-cloudwatch = "1.19.0"
 aws-sdk-dynamodb = "1.19.0"
 aws-sdk-elasticache = "1.18.0"
+phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -24,6 +24,7 @@ aws-sdk-cloudwatch = "1.19.0"
 aws-sdk-dynamodb = "1.19.0"
 aws-sdk-elasticache = "1.18.0"
 phf = { version = "0.11", features = ["macros"] }
+indicatif = "0.17.8"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/momento/src/commands/cloud_linter/elasticache.rs
+++ b/momento/src/commands/cloud_linter/elasticache.rs
@@ -231,5 +231,5 @@ async fn convert_to_resources(
             }
         };
     }
-    return Ok(resources);
+    Ok(resources)
 }

--- a/momento/src/commands/cloud_linter/elasticache.rs
+++ b/momento/src/commands/cloud_linter/elasticache.rs
@@ -1,37 +1,119 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use aws_config::SdkConfig;
 use aws_sdk_elasticache::types::CacheCluster;
 use governor::DefaultDirectRateLimiter;
-use serde::{Deserialize, Serialize};
+use phf::{phf_map, Map};
+use serde::Serialize;
 
+use crate::commands::cloud_linter::metrics::{Metric, MetricTarget, ResourceWithMetrics};
+use crate::commands::cloud_linter::resource::{ElastiCacheResource, Resource, ResourceType};
 use crate::commands::cloud_linter::utils::rate_limit;
 use crate::error::CliError;
 use crate::utils::console::console_info;
 
-#[derive(Serialize, Deserialize)]
+pub(crate) const CACHE_METRICS: Map<&'static str, &'static [&'static str]> = phf_map! {
+        "Sum" => &[
+            "NetworkBytesIn",
+            "NetworkBytesOut",
+            "GeoSpatialBasedCmds",
+            "EvalBasedCmds",
+            "GetTypeCmds",
+            "HashBasedCmds",
+            "JsonBasedCmds",
+            "KeyBasedCmds",
+            "ListBasedCmds",
+            "SetBasedCmds",
+            "SetTypeCmds",
+            "StringBasedCmds",
+            "PubSubBasedCmds",
+            "SortedSetBasedCmds",
+            "StreamBasedCmds",
+        ],
+        "Average" => &[
+            "DB0AverageTTL",
+        ],
+        "Maximum" => &[
+            "CurrConnections",
+            "NewConnections",
+            "EngineCPUUtilization",
+            "CPUUtilization",
+            "FreeableMemory",
+            "BytesUsedForCache",
+            "DatabaseMemoryUsagePercentage",
+            "CurrItems",
+            "KeysTracked",
+            "Evictions",
+            "CacheHitRate",
+        ],
+};
+
+#[derive(Serialize, Clone)]
 pub(crate) struct ElastiCacheMetadata {
+    #[serde(rename = "clusterId")]
     cluster_id: String,
     engine: String,
+    #[serde(rename = "cacheNodeType")]
     cache_node_type: String,
+    #[serde(rename = "preferredAz")]
     preferred_az: String,
+    #[serde(rename = "clusterModeEnabled")]
     cluster_mode_enabled: bool,
 }
 
-pub(crate) async fn get_elasticache_metadata(
-    config: &SdkConfig,
-    limiter: Arc<DefaultDirectRateLimiter>,
-) -> Result<Vec<ElastiCacheMetadata>, CliError> {
-    console_info!("Describing ElastiCache clusters");
-    let elasticache_client = aws_sdk_elasticache::Client::new(config);
-    list_table_names(&elasticache_client, limiter)
-        .await?
-        .into_iter()
-        .map(ElastiCacheMetadata::try_from)
-        .collect()
+impl ResourceWithMetrics for ElastiCacheResource {
+    fn create_metric_target(&self) -> Result<MetricTarget, CliError> {
+        match self.resource_type {
+            ResourceType::ElastiCacheRedisNode => Ok(MetricTarget {
+                namespace: "AWS/ElastiCache".to_string(),
+                dimensions: HashMap::from([
+                    ("CacheClusterId".to_string(), self.id.clone()),
+                    ("CacheNodeId".to_string(), "0001".to_string()),
+                ]),
+                targets: CACHE_METRICS,
+            }),
+            ResourceType::ElastiCacheMemcachedNode => Ok(MetricTarget {
+                namespace: "AWS/ElastiCache".to_string(),
+                dimensions: HashMap::from([
+                    (
+                        "CacheClusterId".to_string(),
+                        self.metadata.cluster_id.clone(),
+                    ),
+                    ("CacheNodeId".to_string(), self.id.clone()),
+                ]),
+                targets: CACHE_METRICS,
+            }),
+            ResourceType::DynamoDbGsi => Err(CliError {
+                msg: "Invalid resource type".to_string(),
+            }),
+            ResourceType::DynamoDbTable => Err(CliError {
+                msg: "Invalid resource type".to_string(),
+            }),
+        }
+    }
+
+    fn set_metrics(&mut self, metrics: Vec<Metric>) {
+        self.metrics = metrics;
+    }
+
+    fn set_metric_period_seconds(&mut self, period: i32) {
+        self.metric_period_seconds = period;
+    }
 }
 
-async fn list_table_names(
+pub(crate) async fn get_elasticache_resources(
+    config: &SdkConfig,
+    limiter: Arc<DefaultDirectRateLimiter>,
+) -> Result<Vec<Resource>, CliError> {
+    console_info!("Describing ElastiCache clusters");
+    let elasticache_client = aws_sdk_elasticache::Client::new(config);
+    let clusters = describe_clusters(&elasticache_client, limiter).await?;
+
+    convert_to_resources(clusters).await
+}
+
+async fn describe_clusters(
     elasticache_client: &aws_sdk_elasticache::Client,
     limiter: Arc<DefaultDirectRateLimiter>,
 ) -> Result<Vec<CacheCluster>, CliError> {
@@ -52,7 +134,7 @@ async fn list_table_names(
             Err(err) => {
                 return Err(CliError {
                     msg: format!("Failed to describe cache clusters: {}", err),
-                })
+                });
             }
         }
     }
@@ -60,53 +142,87 @@ async fn list_table_names(
     Ok(elasticache_clusters)
 }
 
-impl TryFrom<CacheCluster> for ElastiCacheMetadata {
-    type Error = CliError;
+async fn convert_to_resources(clusters: Vec<CacheCluster>) -> Result<Vec<Resource>, CliError> {
+    let mut resources: Vec<Resource> = Vec::new();
 
-    fn try_from(value: CacheCluster) -> Result<Self, Self::Error> {
-        let cache_cluster_id = value.cache_cluster_id.ok_or(CliError {
+    for cluster in clusters {
+        let cache_cluster_id = cluster.cache_cluster_id.ok_or(CliError {
             msg: "ElastiCache cluster has no ID".to_string(),
         })?;
-        let cache_node_type = value.cache_node_type.ok_or(CliError {
+        let cache_node_type = cluster.cache_node_type.ok_or(CliError {
             msg: "ElastiCache cluster has no node type".to_string(),
         })?;
-        let preferred_az = value.preferred_availability_zone.ok_or(CliError {
+        let preferred_az = cluster.preferred_availability_zone.ok_or(CliError {
             msg: "ElastiCache cluster has no preferred availability zone".to_string(),
         })?;
 
-        let engine = value.engine.ok_or(CliError {
+        let engine = cluster.engine.ok_or(CliError {
             msg: "ElastiCache cluster has no node type".to_string(),
         })?;
         match engine.as_str() {
             "redis" => {
-                let (cluster_id, cluster_mode_enabled) = value
+                let (cluster_id, cluster_mode_enabled) = cluster
                     .replication_group_id
                     .map(|replication_group_id| {
-                        let trimmed_cluster_id = cache_cluster_id
+                        let trimmed_cluster_id = cache_cluster_id.clone();
+                        let trimmed_cluster_id = trimmed_cluster_id
                             .trim_start_matches(&format!("{}-", replication_group_id));
                         let parts_len = trimmed_cluster_id.split('-').count();
                         (replication_group_id, parts_len == 2)
                     })
-                    .unwrap_or_else(|| (cache_cluster_id, false));
+                    .unwrap_or_else(|| (cache_cluster_id.clone(), false));
 
-                Ok(ElastiCacheMetadata {
+                let metadata = ElastiCacheMetadata {
                     cluster_id,
                     engine,
                     cache_node_type,
                     preferred_az,
                     cluster_mode_enabled,
-                })
+                };
+
+                let resource = Resource::ElastiCache(ElastiCacheResource {
+                    resource_type: ResourceType::ElastiCacheRedisNode,
+                    region: "".to_string(),
+                    id: cache_cluster_id.clone(),
+                    metrics: vec![],
+                    metric_period_seconds: 0,
+                    metadata,
+                });
+
+                resources.push(resource);
             }
-            "memcached" => Ok(ElastiCacheMetadata {
-                cluster_id: cache_cluster_id,
-                engine,
-                cache_node_type,
-                preferred_az,
-                cluster_mode_enabled: false,
-            }),
-            _ => Err(CliError {
-                msg: format!("Unsupported engine: {}", engine),
-            }),
-        }
+            "memcached" => {
+                let metadata = ElastiCacheMetadata {
+                    cluster_id: cache_cluster_id,
+                    engine,
+                    cache_node_type,
+                    preferred_az,
+                    cluster_mode_enabled: false,
+                };
+
+                if let Some(cache_nodes) = cluster.cache_nodes {
+                    for node in cache_nodes {
+                        let cache_node_id = node.cache_node_id.ok_or(CliError {
+                            msg: "Cache node has no ID".to_string(),
+                        })?;
+                        let resource = Resource::ElastiCache(ElastiCacheResource {
+                            resource_type: ResourceType::ElastiCacheMemcachedNode,
+                            region: "".to_string(),
+                            id: cache_node_id,
+                            metrics: vec![],
+                            metric_period_seconds: 0,
+                            metadata: metadata.clone(),
+                        });
+                        resources.push(resource)
+                    }
+                }
+            }
+            _ => {
+                return Err(CliError {
+                    msg: format!("Unsupported engine: {}", engine),
+                });
+            }
+        };
     }
+    return Ok(resources);
 }

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -21,9 +21,11 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
     let limiter = Arc::new(RateLimiter::direct(quota));
 
     let mut resources = get_ddb_resources(&config, Arc::clone(&limiter)).await?;
+
     let mut elasticache_resources =
         get_elasticache_resources(&config, Arc::clone(&limiter)).await?;
     resources.append(&mut elasticache_resources);
+
     let resources = append_metrics_to_resources(&config, Arc::clone(&limiter), resources).await?;
 
     let data_format = DataFormat { resources };

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use aws_config::{BehaviorVersion, Region};
 use governor::{Quota, RateLimiter};
 
-use crate::commands::cloud_linter::dynamodb::get_ddb_metadata;
-use crate::commands::cloud_linter::elasticache::get_elasticache_metadata;
+use crate::commands::cloud_linter::dynamodb::get_ddb_resources;
+use crate::commands::cloud_linter::elasticache::get_elasticache_resources;
+use crate::commands::cloud_linter::metrics::append_metrics_to_resources;
+use crate::commands::cloud_linter::resource::DataFormat;
 use crate::error::CliError;
 use crate::utils::console::console_info;
 
@@ -18,14 +20,16 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
         Quota::per_second(core::num::NonZeroU32::new(1).expect("should create non-zero quota"));
     let limiter = Arc::new(RateLimiter::direct(quota));
 
-    let ddb_metadata = get_ddb_metadata(&config, Arc::clone(&limiter)).await?;
+    let mut resources = get_ddb_resources(&config, Arc::clone(&limiter)).await?;
+    let mut elasticache_resources =
+        get_elasticache_resources(&config, Arc::clone(&limiter)).await?;
+    resources.append(&mut elasticache_resources);
+    let resources = append_metrics_to_resources(&config, Arc::clone(&limiter), resources).await?;
 
-    let ddb_json = serde_json::to_string_pretty(&ddb_metadata)?;
-    console_info!("DynamoDB metadata:\n{}", ddb_json);
+    let data_format = DataFormat { resources };
+    let data_format_json = serde_json::to_string_pretty(&data_format)?;
 
-    let elasticache_metadata = get_elasticache_metadata(&config, Arc::clone(&limiter)).await?;
-    let elasticache_json = serde_json::to_string_pretty(&elasticache_metadata)?;
-    console_info!("ElastiCache metadata:\n{}", elasticache_json);
+    console_info!("{}", data_format_json);
 
     Ok(())
 }

--- a/momento/src/commands/cloud_linter/metrics.rs
+++ b/momento/src/commands/cloud_linter/metrics.rs
@@ -55,7 +55,7 @@ where
     ) -> Result<(), CliError> {
         let metric_target = self.create_metric_target()?;
         let metrics =
-            query_metrics_for_target(&metrics_client, Arc::clone(&limiter), metric_target).await?;
+            query_metrics_for_target(metrics_client, Arc::clone(&limiter), metric_target).await?;
         self.set_metrics(metrics);
         self.set_metric_period_seconds(60 * 60 * 24);
 

--- a/momento/src/commands/cloud_linter/metrics.rs
+++ b/momento/src/commands/cloud_linter/metrics.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::commands::cloud_linter::resource::Resource;
+use crate::commands::cloud_linter::utils::rate_limit;
+use aws_config::SdkConfig;
+use aws_sdk_cloudwatch::primitives::DateTime;
+use aws_sdk_cloudwatch::types::Metric as CloudwatchMetric;
+use aws_sdk_cloudwatch::types::{Dimension, MetricDataQuery, MetricStat};
+use aws_sdk_cloudwatch::Client;
+use chrono::{Duration, Utc};
+use governor::DefaultDirectRateLimiter;
+use phf::Map;
+use serde::{Deserialize, Serialize};
+
+use crate::error::CliError;
+use crate::utils::console::console_info;
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct Metric {
+    name: String,
+    values: Vec<f64>,
+}
+
+pub(crate) struct MetricTarget {
+    pub(crate) namespace: String,
+    pub(crate) dimensions: HashMap<String, String>,
+    pub(crate) targets: Map<&'static str, &'static [&'static str]>,
+}
+
+pub(crate) trait ResourceWithMetrics {
+    fn create_metric_target(&self) -> Result<MetricTarget, CliError>;
+
+    fn set_metrics(&mut self, metrics: Vec<Metric>);
+
+    fn set_metric_period_seconds(&mut self, period: i32);
+}
+
+pub(crate) trait AppendMetrics {
+    async fn append_metrics(
+        &mut self,
+        config: &Client,
+        limiter: Arc<DefaultDirectRateLimiter>,
+    ) -> Result<(), CliError>;
+}
+
+impl<T> AppendMetrics for T
+where
+    T: ResourceWithMetrics,
+{
+    async fn append_metrics(
+        &mut self,
+        metrics_client: &Client,
+        limiter: Arc<DefaultDirectRateLimiter>,
+    ) -> Result<(), CliError> {
+        let metric_target = self.create_metric_target()?;
+        let metrics =
+            query_metrics_for_target(&metrics_client, Arc::clone(&limiter), metric_target).await?;
+        self.set_metrics(metrics);
+        self.set_metric_period_seconds(60 * 60 * 24);
+
+        Ok(())
+    }
+}
+
+pub(crate) async fn append_metrics_to_resources(
+    config: &SdkConfig,
+    limiter: Arc<DefaultDirectRateLimiter>,
+    mut resources: Vec<Resource>,
+) -> Result<Vec<Resource>, CliError> {
+    console_info!("Getting metrics...");
+    let metrics_client = Client::new(config);
+
+    for resource in &mut resources {
+        match resource {
+            Resource::DynamoDb(dynamodb_resource) => {
+                dynamodb_resource
+                    .append_metrics(&metrics_client, Arc::clone(&limiter))
+                    .await?;
+            }
+            Resource::ElastiCache(elasticache_resource) => {
+                elasticache_resource
+                    .append_metrics(&metrics_client, Arc::clone(&limiter))
+                    .await?;
+            }
+        }
+    }
+
+    Ok(resources)
+}
+
+async fn query_metrics_for_target(
+    client: &Client,
+    limiter: Arc<DefaultDirectRateLimiter>,
+    metric_target: MetricTarget,
+) -> Result<Vec<Metric>, CliError> {
+    let mut metric_results: Vec<Metric> = Vec::new();
+    let dimensions: Vec<Dimension> = metric_target
+        .dimensions
+        .into_iter()
+        .map(|(name, value)| Dimension::builder().name(name).value(value).build())
+        .collect();
+    for (stat_type, metrics) in metric_target.targets.entries() {
+        let mut metric_data_queries: Vec<MetricDataQuery> = Vec::with_capacity(metrics.len());
+        for metric in *metrics {
+            let metric_data_query = MetricDataQuery::builder()
+                .metric_stat(
+                    MetricStat::builder()
+                        .metric(
+                            CloudwatchMetric::builder()
+                                .metric_name(metric.to_string())
+                                .namespace(metric_target.namespace.clone())
+                                .set_dimensions(Some(dimensions.clone()))
+                                .build(),
+                        )
+                        .period(60 * 60 * 24)
+                        .stat(stat_type.to_string())
+                        .build(),
+                )
+                .id(format!(
+                    "{}_{}",
+                    metric.to_lowercase(),
+                    stat_type.to_lowercase()
+                ))
+                .build();
+            metric_data_queries.push(metric_data_query);
+        }
+
+        let mut metric_stream = client
+            .get_metric_data()
+            .start_time(DateTime::from_millis(
+                (Utc::now() - Duration::days(30)).timestamp_millis(),
+            ))
+            .end_time(DateTime::from_millis(Utc::now().timestamp_millis()))
+            .set_metric_data_queries(Some(metric_data_queries))
+            .into_paginator()
+            .send();
+
+        while let Some(result) = rate_limit(Arc::clone(&limiter), || metric_stream.next()).await {
+            let result = result?;
+            if let Some(mdr_vec) = result.metric_data_results {
+                for mdr in mdr_vec {
+                    let name = mdr.id.ok_or_else(|| CliError {
+                        msg: "Metric has no id".to_string(),
+                    })?;
+                    let values = mdr.values.ok_or_else(|| CliError {
+                        msg: "Metric has no values".to_string(),
+                    })?;
+                    metric_results.push(Metric { name, values });
+                }
+            }
+        }
+    }
+
+    Ok(metric_results)
+}

--- a/momento/src/commands/cloud_linter/mod.rs
+++ b/momento/src/commands/cloud_linter/mod.rs
@@ -1,4 +1,6 @@
 mod dynamodb;
 mod elasticache;
 pub mod linter_cli;
+mod metrics;
+mod resource;
 mod utils;

--- a/momento/src/commands/cloud_linter/resource.rs
+++ b/momento/src/commands/cloud_linter/resource.rs
@@ -1,0 +1,53 @@
+use serde::Serialize;
+
+use crate::commands::cloud_linter::dynamodb::DynamoDbMetadata;
+use crate::commands::cloud_linter::elasticache::ElastiCacheMetadata;
+use crate::commands::cloud_linter::metrics::Metric;
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub(crate) enum Resource {
+    DynamoDb(DynamoDbResource),
+    ElastiCache(ElastiCacheResource),
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) enum ResourceType {
+    #[serde(rename = "AWS::DynamoDB::GSI")]
+    DynamoDbGsi,
+    #[serde(rename = "AWS::DynamoDB::Table")]
+    DynamoDbTable,
+    #[serde(rename = "AWS::Elasticache::RedisNode")]
+    ElastiCacheRedisNode,
+    #[serde(rename = "AWS::Elasticache::MemcachedNode")]
+    ElastiCacheMemcachedNode,
+}
+
+#[derive(Serialize)]
+pub(crate) struct DynamoDbResource {
+    #[serde(rename = "type")]
+    pub(crate) resource_type: ResourceType,
+    pub(crate) region: String,
+    pub(crate) id: String,
+    pub(crate) metrics: Vec<Metric>,
+    #[serde(rename = "metricPeriodSeconds")]
+    pub(crate) metric_period_seconds: i32,
+    pub(crate) metadata: DynamoDbMetadata,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ElastiCacheResource {
+    #[serde(rename = "type")]
+    pub(crate) resource_type: ResourceType,
+    pub(crate) region: String,
+    pub(crate) id: String,
+    pub(crate) metrics: Vec<Metric>,
+    #[serde(rename = "metricPeriodSeconds")]
+    pub(crate) metric_period_seconds: i32,
+    pub(crate) metadata: ElastiCacheMetadata,
+}
+
+#[derive(Serialize)]
+pub(crate) struct DataFormat {
+    pub(crate) resources: Vec<Resource>,
+}


### PR DESCRIPTION
Change the get metadata functions for dynamo and elasticache to return a resource that will later be serialized into json.

Add code for fetching metrics based on the dynamo and elasticache resources.

Change the linter cli to print out the full json including the metrics.