### PR TITLE
feat: write linter output to a gzipped JSON file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1028,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "float-cmp"
@@ -1643,6 +1668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1723,7 @@ dependencies = [
  "colored",
  "configparser",
  "env_logger",
+ "flate2",
  "futures",
  "governor",
  "home",

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -25,6 +25,7 @@ aws-sdk-dynamodb = "1.19.0"
 aws-sdk-elasticache = "1.18.0"
 phf = { version = "0.11", features = ["macros"] }
 indicatif = "0.17.8"
+flate2 = "1.0.28"
 
 [dev-dependencies]
 assert_cmd = "2.0.2"

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -1,20 +1,30 @@
+use std::io::Write;
+use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use aws_config::{BehaviorVersion, Region};
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use governor::{Quota, RateLimiter};
+use indicatif::ProgressBar;
+use tokio::fs::{metadata, File};
+use tokio::io::AsyncWriteExt;
 
 use crate::commands::cloud_linter::dynamodb::get_ddb_resources;
 use crate::commands::cloud_linter::elasticache::get_elasticache_resources;
 use crate::commands::cloud_linter::metrics::append_metrics_to_resources;
 use crate::commands::cloud_linter::resource::DataFormat;
 use crate::error::CliError;
-use crate::utils::console::console_info;
 
 pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
     let config = aws_config::defaults(BehaviorVersion::latest())
         .region(Region::new(region))
         .load()
         .await;
+
+    let output_file_path = "linter_results.json.gz";
+    check_output_is_writable(output_file_path).await?;
 
     let quota =
         Quota::per_second(core::num::NonZeroU32::new(1).expect("should create non-zero quota"));
@@ -29,9 +39,45 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
     let resources = append_metrics_to_resources(&config, Arc::clone(&limiter), resources).await?;
 
     let data_format = DataFormat { resources };
-    let data_format_json = serde_json::to_string_pretty(&data_format)?;
 
-    console_info!("{}", data_format_json);
+    write_data_to_file(data_format, output_file_path).await?;
 
     Ok(())
+}
+
+async fn write_data_to_file(data_format: DataFormat, file_path: &str) -> Result<(), CliError> {
+    let bar = ProgressBar::new_spinner().with_message("Writing data to file");
+    bar.enable_steady_tick(Duration::from_millis(100));
+
+    let data_format_json = serde_json::to_string(&data_format)?;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data_format_json.as_bytes())?;
+
+    let compressed_json = encoder.finish()?;
+
+    let mut file = File::create(file_path).await?;
+    file.write_all(&compressed_json).await?;
+
+    bar.finish();
+
+    Ok(())
+}
+
+async fn check_output_is_writable(file_path: &str) -> Result<(), CliError> {
+    let dir = Path::new(file_path).parent().ok_or_else(|| CliError {
+        msg: "Output file has no parent directory".to_string(),
+    })?;
+
+    let metadata = metadata(dir).await.map_err(|_| CliError {
+        msg: "Output file cannot be written".to_string(),
+    })?;
+
+    if metadata.permissions().readonly() {
+        Err(CliError {
+            msg: "Output file cannot be written".to_string(),
+        })
+    } else {
+        Ok(())
+    }
 }

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -15,6 +15,7 @@ use crate::commands::cloud_linter::dynamodb::get_ddb_resources;
 use crate::commands::cloud_linter::elasticache::get_elasticache_resources;
 use crate::commands::cloud_linter::metrics::append_metrics_to_resources;
 use crate::commands::cloud_linter::resource::DataFormat;
+use crate::commands::cloud_linter::utils::check_aws_credentials;
 use crate::error::CliError;
 
 pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
@@ -22,6 +23,7 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
         .region(Region::new(region))
         .load()
         .await;
+    check_aws_credentials(&config).await?;
 
     let output_file_path = "linter_results.json.gz";
     check_output_is_writable(output_file_path).await?;

--- a/momento/src/commands/cloud_linter/utils.rs
+++ b/momento/src/commands/cloud_linter/utils.rs
@@ -46,6 +46,14 @@ impl From<serde_json::Error> for CliError {
     }
 }
 
+impl From<std::io::Error> for CliError {
+    fn from(val: std::io::Error) -> Self {
+        CliError {
+            msg: format!("{val:?}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use governor::{Quota, RateLimiter};


### PR DESCRIPTION
Add a step to check if the output file will be writable before making any network calls.

Gzip compress the final json and write it to linter_results.json.gz in the directory the linter command is executed from.

Check the AWS credentials before starting to provide a better error message than would occur if we made an AWS call with invalid credentials.