### PR TITLE
fix: speed up cloud linter command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ client-cli.iml
 bin/
 momento.exe
 obj/
+*.gz
+

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -28,12 +28,14 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
     let output_file_path = "linter_results.json.gz";
     check_output_is_writable(output_file_path).await?;
 
-    let fast_quota =
-        Quota::per_second(core::num::NonZeroU32::new(10).expect("should create non-zero fast_quota"));
+    let fast_quota = Quota::per_second(
+        core::num::NonZeroU32::new(10).expect("should create non-zero fast_quota"),
+    );
     let fast_limiter = Arc::new(RateLimiter::direct(fast_quota));
 
-    let slow_quota =
-        Quota::per_second(core::num::NonZeroU32::new(1).expect("should create non-zero slow_quota"));
+    let slow_quota = Quota::per_second(
+        core::num::NonZeroU32::new(1).expect("should create non-zero slow_quota"),
+    );
     let slow_limiter = Arc::new(RateLimiter::direct(slow_quota));
 
     let mut resources = get_ddb_resources(&config, Arc::clone(&slow_limiter)).await?;
@@ -42,7 +44,8 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
         get_elasticache_resources(&config, Arc::clone(&fast_limiter)).await?;
     resources.append(&mut elasticache_resources);
 
-    let resources = append_metrics_to_resources(&config, Arc::clone(&fast_limiter), resources).await?;
+    let resources =
+        append_metrics_to_resources(&config, Arc::clone(&fast_limiter), resources).await?;
 
     let data_format = DataFormat { resources };
 

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -28,17 +28,21 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
     let output_file_path = "linter_results.json.gz";
     check_output_is_writable(output_file_path).await?;
 
-    let quota =
-        Quota::per_second(core::num::NonZeroU32::new(1).expect("should create non-zero quota"));
-    let limiter = Arc::new(RateLimiter::direct(quota));
+    let fast_quota =
+        Quota::per_second(core::num::NonZeroU32::new(10).expect("should create non-zero fast_quota"));
+    let fast_limiter = Arc::new(RateLimiter::direct(fast_quota));
 
-    let mut resources = get_ddb_resources(&config, Arc::clone(&limiter)).await?;
+    let slow_quota =
+        Quota::per_second(core::num::NonZeroU32::new(1).expect("should create non-zero slow_quota"));
+    let slow_limiter = Arc::new(RateLimiter::direct(slow_quota));
+
+    let mut resources = get_ddb_resources(&config, Arc::clone(&slow_limiter)).await?;
 
     let mut elasticache_resources =
-        get_elasticache_resources(&config, Arc::clone(&limiter)).await?;
+        get_elasticache_resources(&config, Arc::clone(&fast_limiter)).await?;
     resources.append(&mut elasticache_resources);
 
-    let resources = append_metrics_to_resources(&config, Arc::clone(&limiter), resources).await?;
+    let resources = append_metrics_to_resources(&config, Arc::clone(&fast_limiter), resources).await?;
 
     let data_format = DataFormat { resources };
 


### PR DESCRIPTION
This command just speeds up the elasticache/getMetrics api calls. We need to refactor a bit how the limiter is working. We should be able to query `DescribeDynamodbTables` at a higher rate that we query the `DescribeTimeToLive` api. I spent a bit of time trying to configure separate rate limiters for the ddb api calls, but it was not behaving as expected. I think we might need to first describe all of the ddb tables, maybe have some heuristics around which tables are worth attempting to get a ttl off of, and then call those with a separate slower rate limiter

Before
<img width="536" alt="Screen Shot 2024-04-10 at 6 15 17 PM" src="https://github.com/momentohq/momento-cli/assets/11823378/91c3b41e-ef65-4756-9a64-3552eb441c70">

After
![image](https://github.com/momentohq/momento-cli/assets/11823378/6cf81471-9f10-4d0b-8036-d995cb3da789)
