### PR TITLE
feat: stream resources to files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,7 +720,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -948,6 +948,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "duplicate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de78e66ac9061e030587b2a2e75cc88f22304913c907b11307bca737141230cb"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1124,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1536,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -1567,6 +1577,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-writer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a46aa3d39e9495d71c03e7b68981cd900f17e7ddf2ff97a14583bfbd866f8d23"
+dependencies = [
+ "itoa",
+ "ryu",
 ]
 
 [[package]]
@@ -1718,6 +1738,7 @@ dependencies = [
  "home",
  "humantime",
  "indicatif",
+ "json-writer",
  "lazy_static",
  "log",
  "momento",
@@ -1729,6 +1750,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "struson",
  "tempdir",
  "tokio",
  "toml",
@@ -1983,7 +2005,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2080,6 +2102,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2475,9 +2521,9 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -2550,22 +2596,22 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2700,6 +2746,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "struson"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1ac2aafe0de8ac5f0daf57eab7d8e986724237e03b3092dbb47b867b9c4a76"
+dependencies = [
+ "duplicate",
+ "serde",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2774,22 +2854,22 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.58",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,16 +1580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json-writer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46aa3d39e9495d71c03e7b68981cd900f17e7ddf2ff97a14583bfbd866f8d23"
-dependencies = [
- "itoa",
- "ryu",
-]
-
-[[package]]
 name = "jsonwebtoken"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,7 +1728,6 @@ dependencies = [
  "home",
  "humantime",
  "indicatif",
- "json-writer",
  "lazy_static",
  "log",
  "momento",

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -25,6 +25,8 @@ aws-sdk-dynamodb = "1.19.0"
 aws-sdk-elasticache = "1.18.0"
 indicatif = "0.17.8"
 flate2 = "1.0.28"
+json-writer = "0.3.0"
+struson = { version = "0.5.0", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.2"
@@ -63,7 +65,7 @@ version = "1"
 features = [ "full",]
 
 [dependencies.serde]
-version = "1.0"
+version = "1.0.198"
 features = [ "derive",]
 
 [dependencies.serde_json]

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -25,7 +25,6 @@ aws-sdk-dynamodb = "1.19.0"
 aws-sdk-elasticache = "1.18.0"
 indicatif = "0.17.8"
 flate2 = "1.0.28"
-json-writer = "0.3.0"
 struson = { version = "0.5.0", features = ["serde"] }
 
 [dev-dependencies]

--- a/momento/src/commands/cloud_linter/dynamodb.rs
+++ b/momento/src/commands/cloud_linter/dynamodb.rs
@@ -84,6 +84,8 @@ pub(crate) struct DynamoDbMetadata {
     ttl_enabled: bool,
     #[serde(rename = "isGlobalTable")]
     is_global_table: bool,
+    #[serde(rename = "deleteProtectionEnabled")]
+    delete_protection_enabled: bool,
     #[serde(rename = "lsiCount")]
     lsi_count: i64,
     #[serde(rename = "tableClass")]
@@ -365,6 +367,7 @@ async fn process_table_resources(
         p_throughput_read_units,
         p_throughput_write_units,
         gsi: None,
+        delete_protection_enabled: table.deletion_protection_enabled.unwrap_or_default(),
     };
 
     let mut resources = table

--- a/momento/src/commands/cloud_linter/dynamodb.rs
+++ b/momento/src/commands/cloud_linter/dynamodb.rs
@@ -455,7 +455,9 @@ async fn process_table_resources(
         sender
             .send(Resource::DynamoDb(resource))
             .await
-            .expect("TODO: panic message");
+            .map_err(|err| CliError {
+                msg: format!("Failed to stream dynamodb resource to file: {}", err),
+            })?;
     }
 
     Ok(())

--- a/momento/src/commands/cloud_linter/dynamodb.rs
+++ b/momento/src/commands/cloud_linter/dynamodb.rs
@@ -8,8 +8,11 @@ use governor::DefaultDirectRateLimiter;
 use indicatif::{ProgressBar, ProgressStyle};
 use phf::{phf_map, Map};
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::Sender;
 
-use crate::commands::cloud_linter::metrics::{Metric, MetricTarget, ResourceWithMetrics};
+use crate::commands::cloud_linter::metrics::{
+    AppendMetrics, Metric, MetricTarget, ResourceWithMetrics,
+};
 use crate::commands::cloud_linter::resource::{DynamoDbResource, Resource, ResourceType};
 use crate::commands::cloud_linter::utils::rate_limit;
 use crate::error::CliError;
@@ -67,7 +70,7 @@ const DDB_GSI_METRICS: Map<&'static str, &'static [&'static str]> = phf_map! {
         ],
 };
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub(crate) struct DynamoDbMetadata {
     #[serde(rename = "avgItemSizeBytes")]
     avg_item_size_bytes: i64,
@@ -105,7 +108,7 @@ impl DynamoDbMetadata {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub(crate) struct GsiMetadata {
     #[serde(rename = "gsiName")]
     gsi_name: String,
@@ -164,91 +167,41 @@ impl ResourceWithMetrics for DynamoDbResource {
     }
 }
 
-pub(crate) async fn append_ttl_to_appropriate_ddb_resources(
+pub(crate) async fn process_ddb_resources(
     config: &SdkConfig,
-    mut resources: Vec<Resource>,
-    limiter: Arc<DefaultDirectRateLimiter>,
-) -> Result<Vec<Resource>, CliError> {
-    log::debug!("describing ttl for dynamodb tables");
+    control_plane_limiter: Arc<DefaultDirectRateLimiter>,
+    metrics_limiter: Arc<DefaultDirectRateLimiter>,
+    describe_ttl_limiter: Arc<DefaultDirectRateLimiter>,
+    sender: Sender<Resource>,
+) -> Result<(), CliError> {
     let ddb_client = aws_sdk_dynamodb::Client::new(config);
-    let describe_ddb_ttl_bar =
-        ProgressBar::new(resources.len() as u64).with_message("Describing Dynamo DB Ttl");
-    describe_ddb_ttl_bar
-        .set_style(ProgressStyle::with_template("  {msg} {bar} {eta}").expect("invalid template"));
-    for resource in &mut resources {
-        describe_ddb_ttl_bar.inc(1);
-        match resource {
-            Resource::DynamoDb(r) => {
-                if r.resource_type == ResourceType::DynamoDbGsi {
-                    continue;
-                }
-                let consumed_write_ops_index = r.metrics.iter().position(|p| {
-                    p.name
-                        .eq_ignore_ascii_case("consumedwritecapacityunits_sum")
-                });
-                match consumed_write_ops_index {
-                    Some(index) => {
-                        let consumed_write_capacity =
-                            r.metrics.get(index).expect("index should exist");
-                        let sum: f64 = consumed_write_capacity.values.iter().sum();
-                        // a basic heuristic around whether or not we care to check to see if a ttl exists on a ddb table. If the dynamodb table
-                        // has less than 10 tps average, then we don't care to check if ttl is enabled or not.
-                        if sum < 10.0 * 60.0 * 60.0 * 24.0 * 30.0 {
-                            log::debug!("skipping ttl check for table {}", r.id);
-                            continue;
-                        }
-                        log::debug!("querying ttl for table {}", r.id);
-                        let ttl_enabled =
-                            is_ddb_ttl_enabled(&ddb_client, &r.id, Arc::clone(&limiter)).await?;
-                        r.metadata.ttl_enabled = ttl_enabled;
-                    }
-                    // we did not find that metric, and therefore we assume that there are no consumed capacity units, meaning we don't care to
-                    // check for a ttl on the ddb table
-                    None => {
-                        continue;
-                    }
-                }
-            }
-            Resource::ElastiCache(_) => {
-                continue;
-            }
-        };
-    }
-    describe_ddb_ttl_bar.finish();
-    Ok(resources)
-}
-
-pub(crate) async fn get_ddb_resources(
-    config: &SdkConfig,
-    limiter: Arc<DefaultDirectRateLimiter>,
-) -> Result<Vec<Resource>, CliError> {
-    let ddb_client = aws_sdk_dynamodb::Client::new(config);
+    let metrics_client = aws_sdk_cloudwatch::Client::new(config);
 
     let list_ddb_tables_bar = ProgressBar::new_spinner().with_message("Listing Dynamo DB tables");
     list_ddb_tables_bar.enable_steady_tick(Duration::from_millis(100));
-    let table_names = list_table_names(&ddb_client, Arc::clone(&limiter)).await?;
+    let table_names = list_table_names(&ddb_client, Arc::clone(&control_plane_limiter)).await?;
     list_ddb_tables_bar.finish();
 
     let describe_ddb_tables_bar =
-        ProgressBar::new(table_names.len() as u64).with_message("Describing Dynamo DB tables");
+        ProgressBar::new(table_names.len() as u64).with_message("Processing Dynamo DB tables");
     describe_ddb_tables_bar
         .set_style(ProgressStyle::with_template("  {msg} {bar} {eta}").expect("invalid template"));
-    let mut ddb_resources: Vec<DynamoDbResource> = Vec::new();
     for table_name in table_names {
-        let instances = fetch_ddb_resources(&ddb_client, &table_name, Arc::clone(&limiter)).await?;
-        for instance in instances {
-            ddb_resources.push(instance);
-        }
+        process_table_resources(
+            &ddb_client,
+            &metrics_client,
+            &table_name,
+            Arc::clone(&control_plane_limiter),
+            Arc::clone(&metrics_limiter),
+            Arc::clone(&describe_ttl_limiter),
+            sender.clone(),
+        )
+        .await?;
         describe_ddb_tables_bar.inc(1);
     }
+
     describe_ddb_tables_bar.finish();
-
-    let wrapped_resources = ddb_resources
-        .into_iter()
-        .map(Resource::DynamoDb)
-        .collect::<Vec<Resource>>();
-
-    Ok(wrapped_resources)
+    Ok(())
 }
 
 async fn list_table_names(
@@ -278,13 +231,38 @@ async fn list_table_names(
 
 async fn is_ddb_ttl_enabled(
     ddb_client: &aws_sdk_dynamodb::Client,
-    table_name: &str,
+    resource: &DynamoDbResource,
     limiter: Arc<DefaultDirectRateLimiter>,
 ) -> Result<bool, CliError> {
+    if resource.resource_type == ResourceType::DynamoDbGsi {
+        return Ok(false);
+    };
+    let consumed_write_ops_index = resource.metrics.iter().position(|p| {
+        p.name
+            .eq_ignore_ascii_case("consumedwritecapacityunits_sum")
+    });
+    match consumed_write_ops_index {
+        Some(index) => {
+            let consumed_write_capacity = resource.metrics.get(index).expect("index should exist");
+            let sum: f64 = consumed_write_capacity.values.iter().sum();
+            // a basic heuristic around whether we care to check to see if a ttl exists on a ddb table. If the dynamodb table
+            // has less than 10 tps average, then we don't care to check if ttl is enabled or not.
+            if sum < 10.0 * 60.0 * 60.0 * 24.0 * 30.0 {
+                log::debug!("skipping ttl check for table {}", resource.id);
+                return Ok(false);
+            }
+        }
+        // we did not find that metric, and therefore we assume that there are no consumed capacity units, meaning we don't care to
+        // check for a ttl on the ddb table
+        None => {
+            return Ok(false);
+        }
+    }
+    log::debug!("querying ttl for table {}", resource.id);
     let ttl = rate_limit(Arc::clone(&limiter), || async {
         ddb_client
             .describe_time_to_live()
-            .table_name(table_name)
+            .table_name(&resource.id)
             .send()
             .await
     })
@@ -300,11 +278,15 @@ async fn is_ddb_ttl_enabled(
     Ok(ttl_enabled)
 }
 
-async fn fetch_ddb_resources(
+async fn process_table_resources(
     ddb_client: &aws_sdk_dynamodb::Client,
+    metrics_client: &aws_sdk_cloudwatch::Client,
     table_name: &str,
-    limiter: Arc<DefaultDirectRateLimiter>,
-) -> Result<Vec<DynamoDbResource>, CliError> {
+    control_plane_limiter: Arc<DefaultDirectRateLimiter>,
+    metrics_limiter: Arc<DefaultDirectRateLimiter>,
+    describe_ttl_limiter: Arc<DefaultDirectRateLimiter>,
+    sender: Sender<Resource>,
+) -> Result<(), CliError> {
     let region = ddb_client
         .config()
         .region()
@@ -313,7 +295,7 @@ async fn fetch_ddb_resources(
             msg: "No region configured for client".to_string(),
         })?;
 
-    let description = rate_limit(Arc::clone(&limiter), || async {
+    let description = rate_limit(Arc::clone(&control_plane_limiter), || async {
         ddb_client
             .describe_table()
             .table_name(table_name)
@@ -460,5 +442,18 @@ async fn fetch_ddb_resources(
         metric_period_seconds: 0,
     });
 
-    Ok(resources)
+    for mut resource in resources {
+        resource
+            .append_metrics(metrics_client, Arc::clone(&metrics_limiter))
+            .await?;
+        let ttl_enabled =
+            is_ddb_ttl_enabled(ddb_client, &resource, Arc::clone(&describe_ttl_limiter)).await?;
+        resource.metadata.ttl_enabled = ttl_enabled;
+        sender
+            .send(Resource::DynamoDb(resource))
+            .await
+            .expect("TODO: panic message");
+    }
+
+    Ok(())
 }

--- a/momento/src/commands/cloud_linter/elasticache.rs
+++ b/momento/src/commands/cloud_linter/elasticache.rs
@@ -174,7 +174,7 @@ async fn write_resources(
         })?;
 
         let engine = cluster.engine.ok_or(CliError {
-            msg: "ElastiCache cluster has no node type".to_string(),
+            msg: "ElastiCache cluster has no engine type".to_string(),
         })?;
         match engine.as_str() {
             "redis" => {
@@ -244,14 +244,20 @@ async fn write_resources(
 
     for resource in resources {
         match resource {
-            Resource::DynamoDb(_) => todo!(),
             Resource::ElastiCache(mut er) => {
                 er.append_metrics(&metrics_client, Arc::clone(&metrics_limiter))
                     .await?;
                 sender
                     .send(Resource::ElastiCache(er))
                     .await
-                    .expect("TODO: panic message");
+                    .map_err(|err| CliError {
+                        msg: format!("Failed to send elasticache resource: {}", err),
+                    })?;
+            }
+            _ => {
+                return Err(CliError {
+                    msg: "Invalid resource type".to_string(),
+                });
             }
         }
     }

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -11,6 +11,7 @@ use tokio::fs::{metadata, File};
 use tokio::sync::mpsc::{self, Sender};
 
 use crate::commands::cloud_linter::dynamodb::process_ddb_resources;
+use crate::commands::cloud_linter::serverless_elasticache::process_serverless_elasticache_resources;
 use crate::commands::cloud_linter::utils::check_aws_credentials;
 use crate::error::CliError;
 
@@ -84,6 +85,14 @@ async fn process_data(region: String, sender: Sender<Resource>) -> Result<(), Cl
     .await?;
 
     process_elasticache_resources(
+        &config,
+        Arc::clone(&control_plane_limiter),
+        Arc::clone(&metrics_limiter),
+        sender.clone(),
+    )
+    .await?;
+
+    process_serverless_elasticache_resources(
         &config,
         Arc::clone(&control_plane_limiter),
         Arc::clone(&metrics_limiter),

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -23,7 +23,7 @@ pub async fn run_cloud_linter(region: String) -> Result<(), CliError> {
     // first we check to make sure we have perms to write files to the current directory
     check_output_is_writable(file_path).await?;
 
-    // here we right the unzipped json file, containing all the linter results
+    // here we write the unzipped json file, containing all the linter results
     let unzipped_tokio_file = File::create(file_path).await?;
     let mut unzipped_file = unzipped_tokio_file.into_std().await;
     let mut json_writer = JsonStreamWriter::new(&mut unzipped_file);

--- a/momento/src/commands/cloud_linter/mod.rs
+++ b/momento/src/commands/cloud_linter/mod.rs
@@ -3,4 +3,5 @@ mod elasticache;
 pub mod linter_cli;
 mod metrics;
 mod resource;
+mod serverless_elasticache;
 mod utils;

--- a/momento/src/commands/cloud_linter/resource.rs
+++ b/momento/src/commands/cloud_linter/resource.rs
@@ -3,12 +3,14 @@ use serde::Serialize;
 use crate::commands::cloud_linter::dynamodb::DynamoDbMetadata;
 use crate::commands::cloud_linter::elasticache::ElastiCacheMetadata;
 use crate::commands::cloud_linter::metrics::Metric;
+use crate::commands::cloud_linter::serverless_elasticache::ServerlessElastiCacheMetadata;
 
 #[derive(Serialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum Resource {
     DynamoDb(DynamoDbResource),
     ElastiCache(ElastiCacheResource),
+    ServerlessElastiCache(ServerlessElastiCacheResource),
 }
 
 #[derive(Debug, Serialize, PartialEq)]
@@ -21,6 +23,8 @@ pub(crate) enum ResourceType {
     ElastiCacheRedisNode,
     #[serde(rename = "AWS::Elasticache::MemcachedNode")]
     ElastiCacheMemcachedNode,
+    #[serde(rename = "AWS::Elasticache::Serverless")]
+    ServerlessElastiCache,
 }
 
 #[derive(Serialize, Debug)]
@@ -45,6 +49,18 @@ pub(crate) struct ElastiCacheResource {
     #[serde(rename = "metricPeriodSeconds")]
     pub(crate) metric_period_seconds: i32,
     pub(crate) metadata: ElastiCacheMetadata,
+}
+
+#[derive(Serialize, Debug)]
+pub(crate) struct ServerlessElastiCacheResource {
+    #[serde(rename = "type")]
+    pub(crate) resource_type: ResourceType,
+    pub(crate) region: String,
+    pub(crate) id: String,
+    pub(crate) metrics: Vec<Metric>,
+    #[serde(rename = "metricPeriodSeconds")]
+    pub(crate) metric_period_seconds: i32,
+    pub(crate) metadata: ServerlessElastiCacheMetadata,
 }
 
 #[derive(Serialize, Debug)]

--- a/momento/src/commands/cloud_linter/resource.rs
+++ b/momento/src/commands/cloud_linter/resource.rs
@@ -4,7 +4,7 @@ use crate::commands::cloud_linter::dynamodb::DynamoDbMetadata;
 use crate::commands::cloud_linter::elasticache::ElastiCacheMetadata;
 use crate::commands::cloud_linter::metrics::Metric;
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 #[serde(untagged)]
 pub(crate) enum Resource {
     DynamoDb(DynamoDbResource),
@@ -23,7 +23,7 @@ pub(crate) enum ResourceType {
     ElastiCacheMemcachedNode,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub(crate) struct DynamoDbResource {
     #[serde(rename = "type")]
     pub(crate) resource_type: ResourceType,
@@ -35,7 +35,7 @@ pub(crate) struct DynamoDbResource {
     pub(crate) metadata: DynamoDbMetadata,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub(crate) struct ElastiCacheResource {
     #[serde(rename = "type")]
     pub(crate) resource_type: ResourceType,
@@ -47,7 +47,7 @@ pub(crate) struct ElastiCacheResource {
     pub(crate) metadata: ElastiCacheMetadata,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub(crate) struct DataFormat {
     pub(crate) resources: Vec<Resource>,
 }

--- a/momento/src/commands/cloud_linter/serverless_elasticache.rs
+++ b/momento/src/commands/cloud_linter/serverless_elasticache.rs
@@ -1,0 +1,238 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aws_config::SdkConfig;
+use aws_sdk_elasticache::types::{
+    CacheUsageLimits, DataStorage, DataStorageUnit, EcpuPerSecond, ServerlessCache,
+};
+use governor::DefaultDirectRateLimiter;
+use indicatif::ProgressBar;
+use phf::{phf_map, Map};
+use serde::Serialize;
+use tokio::sync::mpsc::Sender;
+
+use crate::commands::cloud_linter::metrics::{Metric, MetricTarget, ResourceWithMetrics};
+use crate::commands::cloud_linter::resource::{
+    Resource, ResourceType, ServerlessElastiCacheResource,
+};
+use crate::commands::cloud_linter::utils::rate_limit;
+use crate::error::CliError;
+
+use super::metrics::AppendMetrics;
+
+pub(crate) const SERVERLESS_CACHE_METRICS: Map<&'static str, &'static [&'static str]> = phf_map! {
+        "Sum" => &[
+            "NetworkBytesIn",
+            "NetworkBytesOut",
+            "GeoSpatialBasedCmds",
+            "EvalBasedCmds",
+            "EvalBasedCmdsECPUs",
+            "GetTypeCmds",
+            "GetTypeCmdsECPUs" ,
+            "HashBasedCmds",
+            "HashBasedCmdsECPUs",
+            "JsonBasedCmds",
+            "JsonBasedCmdsECPUs",
+            "KeyBasedCmds",
+            "KeyBasedCmdsECPUs",
+            "ListBasedCmds",
+            "ListBasedCmdsECPUs",
+            "SetBasedCmds",
+            "SetBasedCmdsECPUs",
+            "SetTypeCmds",
+            "SetTypeCmdsECPUs",
+            "StringBasedCmds",
+            "StringBasedCmdsECPUs",
+            "PubSubBasedCmds",
+            "PubSubBasedCmdsECPUs",
+            "SortedSetBasedCmds",
+            "SortedSetBasedCmdsECPUs",
+            "StreamBasedCmds",
+            "StreamBasedCmdsECPUs",
+            "ElastiCacheProcessingUnits"
+        ],
+        "Average" => &[
+            "DB0AverageTTL",
+            "ElastiCacheProcessingUnits"
+        ],
+        "Maximum" => &[
+            "CurrConnections",
+            "NewConnections",
+            "EngineCPUUtilization",
+            "CPUUtilization",
+            "FreeableMemory",
+            "BytesUsedForCache",
+            "DatabaseMemoryUsagePercentage",
+            "CurrItems",
+            "KeysTracked",
+            "Evictions",
+            "CacheHitRate",
+        ],
+};
+
+#[derive(Serialize, Clone, Debug)]
+pub(crate) struct ServerlessElastiCacheMetadata {
+    name: String,
+    engine: String,
+    #[serde(rename = "maxDataStorageGB")]
+    max_data_storage_gb: i32,
+    #[serde(rename = "dataStorageUnit")]
+    data_storage_unit: String,
+    #[serde(rename = "maxEcpuPerSecond")]
+    max_ecpu_per_second: i32,
+    #[serde(rename = "snapshotRetentionLimit")]
+    snapshot_retention_limit: i32,
+    #[serde(rename = "dailySnapshotTime")]
+    daily_snapshot_time: String,
+    #[serde(rename = "userGroupId")]
+    user_group_id: String,
+    #[serde(rename = "engineVersion")]
+    engine_version: String,
+}
+
+impl ResourceWithMetrics for ServerlessElastiCacheResource {
+    fn create_metric_target(&self) -> Result<MetricTarget, CliError> {
+        match self.resource_type {
+            ResourceType::ServerlessElastiCache => Ok(MetricTarget {
+                namespace: "AWS/ElastiCache".to_string(),
+                dimensions: HashMap::from([
+                    // the cache id for a serverless elasticache cluster is just the cache name
+                    ("CacheClusterId".to_string(), self.id.clone()),
+                ]),
+                targets: SERVERLESS_CACHE_METRICS,
+            }),
+            _ => Err(CliError {
+                msg: "Invalid resource type".to_string(),
+            }),
+        }
+    }
+
+    fn set_metrics(&mut self, metrics: Vec<Metric>) {
+        self.metrics = metrics;
+    }
+
+    fn set_metric_period_seconds(&mut self, period: i32) {
+        self.metric_period_seconds = period;
+    }
+}
+
+pub(crate) async fn process_serverless_elasticache_resources(
+    config: &SdkConfig,
+    control_plane_limiter: Arc<DefaultDirectRateLimiter>,
+    metrics_limiter: Arc<DefaultDirectRateLimiter>,
+    sender: Sender<Resource>,
+) -> Result<(), CliError> {
+    let region = config.region().map(|r| r.as_ref()).ok_or(CliError {
+        msg: "No region configured for client".to_string(),
+    })?;
+
+    let elasticache_client = aws_sdk_elasticache::Client::new(config);
+    let clusters = describe_clusters(&elasticache_client, control_plane_limiter).await?;
+
+    write_resources(clusters, config, region, sender, metrics_limiter).await?;
+    Ok(())
+}
+
+async fn describe_clusters(
+    elasticache_client: &aws_sdk_elasticache::Client,
+    limiter: Arc<DefaultDirectRateLimiter>,
+) -> Result<Vec<ServerlessCache>, CliError> {
+    let bar =
+        ProgressBar::new_spinner().with_message("Describing Serverless ElastiCache resources");
+    bar.enable_steady_tick(Duration::from_millis(100));
+    let mut serverless_elasticache = Vec::new();
+    let mut elasticache_stream = elasticache_client
+        .describe_serverless_caches()
+        .into_paginator()
+        .send();
+
+    while let Some(result) = rate_limit(Arc::clone(&limiter), || elasticache_stream.next()).await {
+        match result {
+            Ok(result) => {
+                if let Some(caches) = result.serverless_caches {
+                    serverless_elasticache.extend(caches);
+                }
+            }
+            Err(err) => {
+                return Err(CliError {
+                    msg: format!("Failed to describe serverless caches: {}", err),
+                });
+            }
+        }
+    }
+    bar.finish();
+
+    Ok(serverless_elasticache)
+}
+
+async fn write_resources(
+    caches: Vec<ServerlessCache>,
+    config: &SdkConfig,
+    region: &str,
+    sender: Sender<Resource>,
+    metrics_limiter: Arc<DefaultDirectRateLimiter>,
+) -> Result<(), CliError> {
+    let metrics_client = aws_sdk_cloudwatch::Client::new(config);
+
+    for cache in caches {
+        let cache_name = cache.serverless_cache_name.unwrap_or_default();
+        let engine = cache.engine.unwrap_or_default();
+        let user_group_id = cache.user_group_id.unwrap_or_default();
+        let snapshot_retention_limit = cache.snapshot_retention_limit.unwrap_or(0);
+        let daily_snapshot_time = cache.daily_snapshot_time.unwrap_or_default();
+
+        let cache_usage_limits = cache
+            .cache_usage_limits
+            .unwrap_or(CacheUsageLimits::builder().build());
+        // By default, every Serverless cache can scale to a maximum of 5 TBs of data storage and 15,000,000 ECPUs per second. To control costs, you can choose to set lower usage limits so that your cache will scale to a lower maximum.
+        //
+        // When a maximum Memory usage limit is set and your cache hits that limit, then ElastiCache Serverless will begin to evict data, to reject new writes with an Out of Memory error, or both.
+        //
+        // When a maximum ECPUs/second limit is set and your cache hits that limit, then ElastiCache Serverless will begin throttling or rejecting requests.
+        let data_storage = cache_usage_limits.data_storage.unwrap_or(
+            DataStorage::builder()
+                .set_maximum(Some(5_000))
+                .set_unit(Some(DataStorageUnit::Gb))
+                .build(),
+        );
+
+        let ecpu = cache_usage_limits.ecpu_per_second.unwrap_or(
+            EcpuPerSecond::builder()
+                .set_maximum(Some(15_000_000))
+                .build(),
+        );
+        let max_data_storage_gb = data_storage.maximum.unwrap_or(5_000);
+        let data_storage_unit = data_storage.unit.unwrap_or(DataStorageUnit::Gb);
+
+        let metadata = ServerlessElastiCacheMetadata {
+            name: cache_name.clone(),
+            engine,
+            max_data_storage_gb,
+            max_ecpu_per_second: ecpu.maximum.unwrap_or_default(),
+            snapshot_retention_limit,
+            daily_snapshot_time,
+            user_group_id,
+            data_storage_unit: data_storage_unit.to_string(),
+            engine_version: cache.full_engine_version.unwrap_or_default(),
+        };
+
+        let mut serverless_ec_resource = ServerlessElastiCacheResource {
+            resource_type: ResourceType::ServerlessElastiCache,
+            region: region.to_string(),
+            id: cache_name,
+            metrics: vec![],
+            metric_period_seconds: 0,
+            metadata,
+        };
+        serverless_ec_resource
+            .append_metrics(&metrics_client, Arc::clone(&metrics_limiter))
+            .await?;
+
+        let resource = Resource::ServerlessElastiCache(serverless_ec_resource);
+        sender.send(resource).await.map_err(|err| CliError {
+            msg: format!("Failed to send serverless elasticache resource: {}", err),
+        })?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
This pr updates the cloud linter command to be able to stream resources to a file, rather than keep everything in memory, before writing to a file

This main difference in this pr is that the entry point just calls `process_resource_<resource_name>`, and then the resource is in charge of getting all metadata/metrics, and then streaming the results to a file. Previously, the `process_resource` function would return the resources for further processing