### PR TITLE
fix: still working on GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Output release
         id: release
-        run: echo "release=${{ steps.semrel.outputs.version }}" >> $ENV:GITHUB_OUTPUT
+        run: echo "release=${{ steps.semrel.outputs.version }}" >> $GITHUB_OUTPUT
 
   publish-linux-assets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now I'm thinking that all the ones that happen on Windows need
to be `$ENV:GITHUB_OUTPUT` and the ones that happen on mac/linux
need to be just `$GITHUB_OUTPUT`.
