### PR TITLE
feat: Make the cloud linter start and end dates configurable

### DIFF
--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -258,12 +258,12 @@ to help find opportunities for optimizations with Momento.
         metric_collection_rate: u32,
         #[arg(
             long = "start-date",
-            help = "The UTC start date of the metric collection period. Will use (end-date - 30 days) if not provided. (YYYY-MM-DD)"
+            help = "The inclusive UTC start date of the metric collection period. Will use (end-date - 30 days) if not provided. (YYYY-MM-DD)"
         )]
         metric_start_date: Option<String>,
         #[arg(
             long = "end-date",
-            help = "The UTC end date of the metric collection period. Will use the current date if not provided. (YYYY-MM-DD)"
+            help = "The inclusive UTC end date of the metric collection period. Will use the current date if not provided. (YYYY-MM-DD)"
         )]
         metric_end_date: Option<String>,
     },

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -256,6 +256,16 @@ to help find opportunities for optimizations with Momento.
             default_value = "10"
         )]
         metric_collection_rate: u32,
+        #[arg(
+            long = "start-date",
+            help = "The UTC start date of the metric collection period. Will use (end-date - 30 days) if not provided. (YYYY-MM-DD)"
+        )]
+        metric_start_date: Option<String>,
+        #[arg(
+            long = "end-date",
+            help = "The UTC end date of the metric collection period. Will use the current date if not provided. (YYYY-MM-DD)"
+        )]
+        metric_end_date: Option<String>,
     },
 }
 

--- a/momento/src/commands/cloud_linter/api_gateway.rs
+++ b/momento/src/commands/cloud_linter/api_gateway.rs
@@ -69,6 +69,7 @@ impl ResourceWithMetrics for ApiGatewayResource {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_api_gateway_resources(
     config: &SdkConfig,
     control_plane_limiter: Arc<DefaultDirectRateLimiter>,
@@ -118,6 +119,7 @@ pub(crate) async fn process_api_gateway_resources(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_apis(
     apig_client: aws_sdk_apigateway::Client,
     metrics_client: &aws_sdk_cloudwatch::Client,

--- a/momento/src/commands/cloud_linter/dynamodb.rs
+++ b/momento/src/commands/cloud_linter/dynamodb.rs
@@ -206,6 +206,7 @@ impl ResourceWithMetrics for DynamoDbResource {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_ddb_resources(
     config: &SdkConfig,
     control_plane_limiter: Arc<DefaultDirectRateLimiter>,

--- a/momento/src/commands/cloud_linter/elasticache.rs
+++ b/momento/src/commands/cloud_linter/elasticache.rs
@@ -111,6 +111,8 @@ pub(crate) async fn process_elasticache_resources(
     control_plane_limiter: Arc<DefaultDirectRateLimiter>,
     metrics_limiter: Arc<DefaultDirectRateLimiter>,
     sender: Sender<Resource>,
+    metrics_start_millis: i64,
+    metrics_end_millis: i64,
 ) -> Result<(), CliError> {
     let region = config.region().map(|r| r.as_ref()).ok_or(CliError {
         msg: "No region configured for client".to_string(),
@@ -123,8 +125,10 @@ pub(crate) async fn process_elasticache_resources(
         &metrics_client,
         control_plane_limiter,
         metrics_limiter,
-        region,
         sender,
+        region,
+        metrics_start_millis,
+        metrics_end_millis,
     )
     .await?;
 
@@ -136,8 +140,10 @@ async fn process_resources(
     metrics_client: &aws_sdk_cloudwatch::Client,
     control_plane_limiter: Arc<DefaultDirectRateLimiter>,
     metrics_limiter: Arc<DefaultDirectRateLimiter>,
-    region: &str,
     sender: Sender<Resource>,
+    region: &str,
+    metrics_start_millis: i64,
+    metrics_end_millis: i64,
 ) -> Result<(), CliError> {
     let describe_bar = ProgressBar::new_spinner().with_message("Listing ElastiCache resources");
     describe_bar.enable_steady_tick(Duration::from_millis(100));
@@ -165,7 +171,12 @@ async fn process_resources(
 
             futures.push(tokio::spawn(async move {
                 resource
-                    .append_metrics(&metrics_client_clone, metrics_limiter_clone)
+                    .append_metrics(
+                        &metrics_client_clone,
+                        metrics_limiter_clone,
+                        metrics_start_millis,
+                        metrics_end_millis,
+                    )
                     .await?;
 
                 let wrapped_resource = Resource::ElastiCache(resource);

--- a/momento/src/commands/cloud_linter/elasticache.rs
+++ b/momento/src/commands/cloud_linter/elasticache.rs
@@ -135,6 +135,7 @@ pub(crate) async fn process_elasticache_resources(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_resources(
     elasticache_client: &aws_sdk_elasticache::Client,
     metrics_client: &aws_sdk_cloudwatch::Client,

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -293,7 +293,7 @@ fn get_metric_time_range(
 
 fn parse_date_string(date: &str) -> Result<NaiveDateTime, CliError> {
     let naive_date = NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|_| CliError {
-        msg: "Date must be in ISO 8601 (YYYY-MM-DD) format".to_string(),
+        msg: "Date must be in YYYY-MM-DD format".to_string(),
     })?;
     naive_date.and_hms_opt(0, 0, 0).ok_or_else(|| CliError {
         msg: "invalid time".to_string(),

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -292,7 +292,9 @@ fn get_metric_time_range(
 }
 
 fn parse_date_string(date: &str) -> Result<NaiveDateTime, CliError> {
-    let naive_date = NaiveDate::parse_from_str(date, "%Y-%m-%d")?;
+    let naive_date = NaiveDate::parse_from_str(date, "%Y-%m-%d").map_err(|_| CliError {
+        msg: "Date must be in ISO 8601 (YYYY-MM-DD) format".to_string(),
+    })?;
     naive_date.and_hms_opt(0, 0, 0).ok_or_else(|| CliError {
         msg: "invalid time".to_string(),
     })

--- a/momento/src/commands/cloud_linter/s3.rs
+++ b/momento/src/commands/cloud_linter/s3.rs
@@ -124,6 +124,7 @@ impl ResourceWithMetrics for S3Resource {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_s3_resources(
     config: &SdkConfig,
     control_plane_limiter: Arc<DefaultDirectRateLimiter>,
@@ -237,6 +238,7 @@ async fn try_get_bucket_metrics_filter(
     Ok("".to_string())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_buckets(
     s3client: aws_sdk_s3::Client,
     metrics_client: &aws_sdk_cloudwatch::Client,
@@ -300,6 +302,7 @@ async fn process_buckets(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_bucket(
     s3client: aws_sdk_s3::Client,
     metrics_client: &aws_sdk_cloudwatch::Client,

--- a/momento/src/commands/cloud_linter/serverless_elasticache.rs
+++ b/momento/src/commands/cloud_linter/serverless_elasticache.rs
@@ -119,6 +119,7 @@ impl ResourceWithMetrics for ServerlessElastiCacheResource {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn process_serverless_elasticache_resources(
     config: &SdkConfig,
     control_plane_limiter: Arc<DefaultDirectRateLimiter>,
@@ -148,6 +149,7 @@ pub(crate) async fn process_serverless_elasticache_resources(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn process_resources(
     elasticache_client: &aws_sdk_elasticache::Client,
     metrics_client: &aws_sdk_cloudwatch::Client,

--- a/momento/src/commands/cloud_linter/utils.rs
+++ b/momento/src/commands/cloud_linter/utils.rs
@@ -58,6 +58,14 @@ impl From<std::io::Error> for CliError {
     }
 }
 
+impl From<chrono::ParseError> for CliError {
+    fn from(val: chrono::ParseError) -> Self {
+        CliError {
+            msg: format!("{val:?}"),
+        }
+    }
+}
+
 pub(crate) async fn check_aws_credentials(config: &SdkConfig) -> Result<(), CliError> {
     if let Some(credentials_provider) = config.credentials_provider() {
         let credentials = credentials_provider

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -271,6 +271,8 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 enable_gsi,
                 enable_s3,
                 enable_api_gateway,
+                metric_start_date,
+                metric_end_date,
             } => {
                 commands::cloud_linter::linter_cli::run_cloud_linter(
                     region,
@@ -280,6 +282,8 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                     enable_api_gateway,
                     resource,
                     metric_collection_rate,
+                    metric_start_date,
+                    metric_end_date,
                 )
                 .await?;
             }


### PR DESCRIPTION
Add optional arguments to the cloud-linter command that take a start and end date in YYYY-MM-DD form. If the start-date isn't provided, it defaults to end-date - 30. If end-date isn't provided, it defaults to today.

Make the process resources function argument orders consistent.

Delete some commented out code.