### PR TITLE
feat: add cloud linter options to filter by elasticache engine

### DIFF
--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -275,6 +275,9 @@ pub enum CloudLinterResources {
     S3,
     Dynamo,
     ElastiCache,
+    ElastiCacheRedis,
+    ElastiCacheMemcached,
+    ElastiCacheServerless,
 }
 
 #[derive(Debug, Parser)]

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -23,7 +23,7 @@ use crate::commands::cloud_linter::utils::check_aws_credentials;
 use crate::error::CliError;
 
 use super::elasticache::process_elasticache_resources;
-use super::resource::Resource;
+use super::resource::{Resource, ResourceType};
 
 #[allow(clippy::too_many_arguments)]
 pub async fn run_cloud_linter(
@@ -180,9 +180,48 @@ async fn process_data(
                     sender.clone(),
                     metrics_start_millis,
                     metrics_end_millis,
+                    None,
                 )
                 .await?;
 
+                process_serverless_elasticache_resources(
+                    &config,
+                    Arc::clone(&control_plane_limiter),
+                    Arc::clone(&metrics_limiter),
+                    sender.clone(),
+                    metrics_start_millis,
+                    metrics_end_millis,
+                )
+                .await?;
+                Ok(())
+            }
+            CloudLinterResources::ElastiCacheRedis => {
+                process_elasticache_resources(
+                    &config,
+                    Arc::clone(&control_plane_limiter),
+                    Arc::clone(&metrics_limiter),
+                    sender.clone(),
+                    metrics_start_millis,
+                    metrics_end_millis,
+                    Some(ResourceType::ElastiCacheRedisNode),
+                )
+                .await?;
+                Ok(())
+            }
+            CloudLinterResources::ElastiCacheMemcached => {
+                process_elasticache_resources(
+                    &config,
+                    Arc::clone(&control_plane_limiter),
+                    Arc::clone(&metrics_limiter),
+                    sender.clone(),
+                    metrics_start_millis,
+                    metrics_end_millis,
+                    Some(ResourceType::ElastiCacheMemcachedNode),
+                )
+                .await?;
+                Ok(())
+            }
+            CloudLinterResources::ElastiCacheServerless => {
                 process_serverless_elasticache_resources(
                     &config,
                     Arc::clone(&control_plane_limiter),
@@ -241,6 +280,7 @@ async fn process_data(
         sender.clone(),
         metrics_start_millis,
         metrics_end_millis,
+        None,
     )
     .await?;
 

--- a/momento/src/commands/cloud_linter/resource.rs
+++ b/momento/src/commands/cloud_linter/resource.rs
@@ -17,7 +17,7 @@ pub(crate) enum Resource {
     S3(S3Resource),
 }
 
-#[derive(Debug, Serialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, PartialEq, Eq, Copy, Clone)]
 pub(crate) enum ResourceType {
     #[serde(rename = "AWS::ApiGateway::API")]
     ApiGateway,


### PR DESCRIPTION
Add new cloud linter flags: elasti-cache-redis, elasti-cache-memcached, and elasti-cache-serverless, in addition to the existing elasti-cache flag. These limit the cloud linter to only process elasticache clusters with the redis or memcached engines, or only serverless clusters.

Add a stub section for valkey elasticache clusters, to be filled out in the future.

Make the unknown engine option return an empty vec instead of an error, because the previously unknown valkey engine was breaking processing when encountered.