### PR TITLE
Add ElastiCacheValkey resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+.PHONY: all
+## Generate sync unit tests, format, lint, and test
+all: precommit
+
+.PHONY: format
+## Format all files
+format:
+	cargo fmt
+
+.PHONY: lint
+## Check the formatting of all files, run clippy on the source code, then run
+## clippy on the tests (but allow expect to be used in tests)
+lint:
+	cargo fmt -- --check && \
+	cargo clippy --all-features -- -D warnings -W clippy::unwrap_used && \
+	cargo clippy --tests -- -D warnings -W clippy::unwrap_used
+
+.PHONY: build
+## Build project
+build:
+	cargo build --verbose
+
+.PHONY: clean
+## Remove build files
+clean:
+	cargo clean
+
+.PHONY: clean-build
+## Build project
+clean-build: clean build
+
+.PHONY: precommit
+## Run clean-build and test as a step before committing.
+precommit: clean-build lint test build-examples
+
+.PHONY: test-unit
+test-unit:
+	cargo test --lib
+
+.PHONY: test-sequentially
+test-sequentially:
+	./run_test_sequentially.sh
+
+.PHONY: test
+test: test-unit test-sequentially
+
+.PHONY: run-cloud-linter
+run-cloud-linter:
+	AWS_PROFILE=dev cargo run -- preview cloud-linter --region us-west-2
+
+# See <https://gist.github.com/klmr/575726c7e05d8780505a> for explanation.
+.PHONY: help
+help:
+	@echo "$$(tput bold)Available rules:$$(tput sgr0)";echo;sed -ne"/^## /{h;s/.*//;:d" -e"H;n;s/^## //;td" -e"s/:.*//;G;s/\\n## /---/;s/\\n/ /g;p;}" ${MAKEFILE_LIST}|LC_ALL='C' sort -f|awk -F --- -v n=$$(tput cols) -v i=19 -v a="$$(tput setaf 6)" -v z="$$(tput sgr0)" '{printf"%s%*s%s ",a,-i,$$1,z;m=split($$2,w," ");l=n-i;for(j=1;j<=m;j++){l-=length(w[j])+1;if(l<= 0){l=n-i-length(w[j])-1;printf"\n%*s ",-i," ";}printf"%s ",w[j];}printf"\n";}'|more $(shell test $(shell uname) == Darwin && echo '-Xr')
+

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -278,6 +278,7 @@ pub enum CloudLinterResources {
     ElastiCacheRedis,
     ElastiCacheMemcached,
     ElastiCacheServerless,
+    ElastiCacheValkey,
 }
 
 #[derive(Debug, Parser)]

--- a/momento/src/commands/cloud_linter/linter_cli.rs
+++ b/momento/src/commands/cloud_linter/linter_cli.rs
@@ -221,6 +221,19 @@ async fn process_data(
                 .await?;
                 Ok(())
             }
+            CloudLinterResources::ElastiCacheValkey => {
+                process_elasticache_resources(
+                    &config,
+                    Arc::clone(&control_plane_limiter),
+                    Arc::clone(&metrics_limiter),
+                    sender.clone(),
+                    metrics_start_millis,
+                    metrics_end_millis,
+                    Some(ResourceType::ElastiCacheValkeyNode),
+                )
+                .await?;
+                Ok(())
+            }
             CloudLinterResources::ElastiCacheServerless => {
                 process_serverless_elasticache_resources(
                     &config,

--- a/momento/src/commands/cloud_linter/resource.rs
+++ b/momento/src/commands/cloud_linter/resource.rs
@@ -29,6 +29,8 @@ pub(crate) enum ResourceType {
     ElastiCacheRedisNode,
     #[serde(rename = "AWS::Elasticache::MemcachedNode")]
     ElastiCacheMemcachedNode,
+    #[serde(rename = "AWS::Elasticache::ValkeyNode")]
+    ElastiCacheValkeyNode,
     #[serde(rename = "AWS::Elasticache::Serverless")]
     ServerlessElastiCache,
     #[serde(rename = "AWS::S3::Bucket")]


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1122

Made some demo caches in aws elasticache console. 
The homebrew published broke (did not process elasticache resources). 
The locally-built version of momento-cli of this branch appears to be working and scraping the valkey data though!
Essentially copied the elasticache redis components to do so. Let me know if there's anything else that should be tweaked though! 