### PR TITLE
chore: add error_count_sum metric for elasticache resources in cloud linter

### DIFF
--- a/momento/src/commands/cloud_linter/elasticache.rs
+++ b/momento/src/commands/cloud_linter/elasticache.rs
@@ -36,6 +36,7 @@ pub(crate) const CACHE_METRICS: Map<&'static str, &'static [&'static str]> = phf
             "PubSubBasedCmds",
             "SortedSetBasedCmds",
             "StreamBasedCmds",
+            "ErrorCount",
         ],
         "Average" => &[
             "DB0AverageTTL",


### PR DESCRIPTION
Work towards https://github.com/momentohq/dev-eco-issue-tracker/issues/1234

Verified that dynamodb metrics include read and write throttles ([reference](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/metrics-dimensions.html)). There's no throttling metric for elasticache, but found [ErrorCount](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/CacheMetrics.Redis.html#:~:text=Microseconds-,ErrorCount,-The%20total%20number), so taking the sum of that to include in the cloud linter data collection too.