### PR TITLE
chore: for topics subscribe messages, use Display instead of Debug

### DIFF
--- a/momento/src/commands/topic/mod.rs
+++ b/momento/src/commands/topic/mod.rs
@@ -6,7 +6,7 @@ use crate::utils::console::console_data;
 pub async fn print_subscription(mut subscription: Subscription) -> MomentoResult<()> {
     while let Some(item) = subscription.next().await {
         match item.kind {
-            momento::topics::ValueKind::Text(text) => console_data!("{:?}", text),
+            momento::topics::ValueKind::Text(text) => console_data!("{text}"),
             momento::topics::ValueKind::Binary(binary) => {
                 console_data!("{:?}", binary)
             }


### PR DESCRIPTION
When displaying `Text` messages, we should use `Display` rather than `Debug`

This should ensure text with characters like `\n` are properly rendered
