### PR TITLE
chore: remove `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.90.0"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
`rust-toolchain.toml` was removed from [#363](https://github.com/momentohq/momento-cli/pull/363#discussion_r3012156413) but accidentally committed in #364.

**Note to self:** After a PR base changes, re-run checks **and** `rebase main` before re-requesting review (or at least re-run checks + check the final `diff main`), even if I'm confident :)