### PR TITLE
feat: pin version with `put-function-config`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb9504b110f5084c95af67e0eaf42d8810b02c25951faf994da11a83da33bc1"
+checksum = "96ab846d102b57272d0da158fd532d9ed72280e00045b0c0491ead04ea9171d8"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -2453,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.128.2"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b06b41c5c34c07bc99048f38cdf073467414460bb5fa6231fb45971d68dec06"
+checksum = "0da49420d6a1e070d54831d9ed72af16e08f3e67850df566c9f6a6409f29ae62"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -189,6 +189,11 @@ pub enum FunctionCommand {
     #[command(
     about = "Update a Momento Function's configuration",
     group(
+    clap::ArgGroup::new("function-specifier")
+    .required(true)
+    .args(["function_name", "function_id"]),
+    ),
+    group(
     clap::ArgGroup::new("version")
     .args(["pin_version", "use_latest_version"]),
     ),
@@ -201,13 +206,20 @@ pub enum FunctionCommand {
             value_name = "CACHE"
         )]
         cache_name: Option<String>,
+
         #[arg(
             long = "name",
-            short,
+            short = 'n',
             help = "Name of the function you want to update",
             value_name = "FUNCTION"
         )]
-        name: String,
+        function_name: Option<String>,
+        #[arg(
+            long = "id",
+            help = "ID of the function you want to update",
+            value_name = "FUNCTION"
+        )]
+        function_id: Option<String>,
 
         #[arg(
             long = "pin-version",

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -195,6 +195,7 @@ pub enum FunctionCommand {
     ),
     group(
     clap::ArgGroup::new("version")
+    .required(true)
     .args(["pin_version", "use_latest_version"]),
     ),
     )]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -186,6 +186,42 @@ pub enum FunctionCommand {
         )]
         environment_variables: Vec<(String, String)>,
     },
+    #[command(
+    about = "Update a Momento Function's configuration",
+    group(
+    clap::ArgGroup::new("version")
+    .args(["pin_version", "use_latest_version"]),
+    ),
+    )]
+    PutFunctionConfig {
+        #[arg(
+            long = "cache-name",
+            short,
+            help = "Name of the cache used as your function namespace [default: your profile's default cache]",
+            value_name = "CACHE"
+        )]
+        cache_name: Option<String>,
+        #[arg(
+            long = "name",
+            short,
+            help = "Name of the function you want to update",
+            value_name = "FUNCTION"
+        )]
+        name: String,
+
+        #[arg(
+            long = "pin-version",
+            help = "Always invoke this specific version of the function. Example: --pin-version 42",
+            value_name = "VERSION"
+        )]
+        pin_version: Option<u32>,
+        #[arg(
+            long = "use-latest-version",
+            help = "Always invoke the latest available version of the function",
+            default_value_t = false
+        )]
+        use_latest_version: bool,
+    },
     #[command(about = "Create or update a Wasm source that can be used in a Momento Function")]
     PutWasm {
         #[arg(long = "name", short, help = "Wasm source name")]
@@ -205,7 +241,7 @@ pub enum FunctionCommand {
         #[arg(
             long = "cache-name",
             short,
-            help = "Name of the cache you want to use as your function namespace [default: your profile's default cache]",
+            help = "Name of the cache used as your function namespace [default: your profile's default cache]",
             value_name = "CACHE"
         )]
         cache_name: Option<String>,

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -217,6 +217,7 @@ pub enum FunctionCommand {
         function_name: Option<String>,
         #[arg(
             long = "id",
+            short = 'i',
             help = "ID of the function you want to update",
             value_name = "FUNCTION"
         )]

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -43,7 +43,7 @@ features = [ "macros",]
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-version = "0.61.0"
+version = "0.63.0"
 
 [dependencies.futures]
 version = "0.3.28"

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -53,13 +53,22 @@ pub async fn put_function(
 pub async fn put_function_config(
     client: FunctionClient,
     cache_name: String,
-    name: String,
+    function_name: Option<String>,
+    function_id: Option<String>,
     new_version: Option<CurrentFunctionVersion>,
 ) -> Result<(), CliError> {
-    let mut request = PutFunctionConfigRequest::from_function_name(&cache_name, &name);
+    let mut request = if let Some(name) = function_name {
+        PutFunctionConfigRequest::from_function_name(&cache_name, &name)
+    } else if let Some(id) = function_id {
+        PutFunctionConfigRequest::from_function_id(&cache_name, &id)
+    } else {
+        return Err(CliError::new("Function name or ID must be specified"));
+    };
+
     if let Some(new_version) = new_version {
         request = request.current_version(new_version);
     }
+
     let response = client.send(request).await.map_err(Into::<CliError>::into)?;
     console_data!(
         "Function config updated! Name: {}, ID: {}, Latest Version: {}, Current Version: {}",

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -41,12 +41,24 @@ pub async fn put_function(
     }
     request = request.environment(environment_variables);
     let response = client.send(request).await.map_err(Into::<CliError>::into)?;
-    console_data!(
-        "Function uploaded or updated! Name: {}, ID: {}, Version: {}",
+    let uploaded_version = response.latest_version();
+    let current_version = response.version();
+    if uploaded_version == current_version {
+        console_data!(
+            "Function uploaded or updated! Name: {}, ID: {}, Latest Version: {}",
+            response.name(),
+            response.function_id(),
+            uploaded_version,
+        );
+    } else {
+        console_data!(
+        "Function version uploaded but not in use. Name: {}, ID: {}, Latest Version: {}, Current Version: {}",
         response.name(),
         response.function_id(),
-        response.version()
+        uploaded_version,
+        current_version,
     );
+    }
     Ok(())
 }
 
@@ -143,9 +155,10 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
         console_data!("Functions in cache namespace: {cache_name}");
         functions_list.iter().for_each(|function| {
             console_data!(
-                "Name: {}, ID: {}, Version: {}, Description: {}, Last Updated: {}",
+                "Name: {}, ID: {}, Latest Version: {}, Current Version: {}, Description: {}, Last Uploaded: {}",
                 function.name(),
                 function.function_id(),
+                function.latest_version(),
                 function.version(),
                 function.description(),
                 function.last_updated_at(),

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -45,7 +45,7 @@ pub async fn put_function(
     let current_version = response.version();
     if uploaded_version == current_version {
         console_data!(
-            "Function uploaded or updated! Name: {}, ID: {}, Latest Version: {}",
+            "Function uploaded or updated! Name: {}, ID: {}, Version: {}",
             response.name(),
             response.function_id(),
             uploaded_version,

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -1,7 +1,7 @@
 use momento::{
     functions::{
-        ListFunctionVersionsRequest, ListFunctionsRequest, ListWasmsRequest, PutFunctionRequest,
-        PutWasmRequest, WasmSource,
+        CurrentFunctionVersion, ListFunctionVersionsRequest, ListFunctionsRequest,
+        ListWasmsRequest, PutFunctionConfigRequest, PutFunctionRequest, PutWasmRequest, WasmSource,
     },
     FunctionClient,
 };
@@ -46,6 +46,27 @@ pub async fn put_function(
         response.name(),
         response.function_id(),
         response.version()
+    );
+    Ok(())
+}
+
+pub async fn put_function_config(
+    client: FunctionClient,
+    cache_name: String,
+    name: String,
+    new_version: Option<CurrentFunctionVersion>,
+) -> Result<(), CliError> {
+    let mut request = PutFunctionConfigRequest::from_function_name(&cache_name, &name);
+    if let Some(new_version) = new_version {
+        request = request.current_version(new_version);
+    }
+    let response = client.send(request).await.map_err(Into::<CliError>::into)?;
+    console_data!(
+        "Function config updated! Name: {}, ID: {}, Latest Version: {}, Current Version: {}",
+        response.name(),
+        response.function_id(),
+        response.latest_version(),
+        response.version(),
     );
     Ok(())
 }

--- a/momento/src/commands/functions/utils.rs
+++ b/momento/src/commands/functions/utils.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::str::FromStr; // to use HeaderName::from_str
 
-use momento::functions::WasmSource;
+use momento::functions::{CurrentFunctionVersion, WasmSource};
 
 use crate::error::CliError;
 
@@ -35,6 +35,18 @@ pub fn determine_wasm_source(
     _ => Err(CliError::new(
         "Must provide a .wasm file compiled with wasm32-wasip2 to upload using the --wasm-file flag or a previously uploaded Wasm using the --id-uploaded-wasm and --version-uploaded-wasm flags",
     )),
+    }
+}
+
+/// put-function-config
+pub fn determine_current_function_version(
+    pin_version: Option<u32>,
+    use_latest_version: bool,
+) -> Option<CurrentFunctionVersion> {
+    if use_latest_version {
+        Some(CurrentFunctionVersion::Latest)
+    } else {
+        pin_version.map(CurrentFunctionVersion::Pinned)
     }
 }
 

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -14,7 +14,9 @@ use utils::{
 };
 
 use crate::{
-    commands::functions::utils::{determine_wasm_source, InvocationOptions},
+    commands::functions::utils::{
+        determine_current_function_version, determine_wasm_source, InvocationOptions,
+    },
     utils::console::console_info,
 };
 
@@ -254,6 +256,23 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                             wasm_source,
                             description,
                             environment_variables,
+                        )
+                        .await?
+                    }
+                    momento_cli_opts::FunctionCommand::PutFunctionConfig {
+                        cache_name,
+                        name,
+                        pin_version,
+                        use_latest_version,
+                    } => {
+                        let cache_name = cache_name.unwrap_or(config.cache);
+                        let new_version =
+                            determine_current_function_version(pin_version, use_latest_version);
+                        commands::functions::function_cli::put_function_config(
+                            client,
+                            cache_name,
+                            name,
+                            new_version,
                         )
                         .await?
                     }

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -261,7 +261,8 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                     }
                     momento_cli_opts::FunctionCommand::PutFunctionConfig {
                         cache_name,
-                        name,
+                        function_name,
+                        function_id,
                         pin_version,
                         use_latest_version,
                     } => {
@@ -271,7 +272,8 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         commands::functions::function_cli::put_function_config(
                             client,
                             cache_name,
-                            name,
+                            function_name,
+                            function_id,
                             new_version,
                         )
                         .await?


### PR DESCRIPTION
This PR implements the `put-function-config` command, which so far allows customers to pin their Momento Function to a specific version, instead of always following the latest version.

I also adjusted `put-function` and `list-functions` to better reflect the new difference between a function's current version vs latest version.

## Sample Usage

**Pin a specific function version** (corresponding to a specific WASM):

```bash
cargo run -q -- preview function \
  put-function-config --name ping --pin-version 10
# Function config updated! Name: ping, ID: f-asdfljsdf, Latest Version: 14, Current Version: 10

cargo run -q -- preview function \
  put-function --name ping --wasm-file ../wasm/web_function_hello_world.wasm
# Function version uploaded but not in use. Name: ping, ID: f-asdfljsdf, Latest Version: 15, Current Version: 10

cargo run -q -- preview function \
  invoke-function --name ping
# pong

cargo run -q -- preview function list-functions
# Name: ping, ID: f-asdfljsdf, Latest Version: 15, Current Version: 10, Description: , Last Uploaded: 2026-04-16T18:41:04.221688861+00:00
```

**Go back to using/following the latest function version:**

```bash
cargo run -q -- preview function \
  put-function-config --name ping --use-latest-version
# Function config updated! Name: ping, ID: f-asdfljsdf, Latest Version: 15, Current Version: 15

cargo run -q -- preview function \
  invoke-function --name ping
# hello world

cargo run -q -- preview function \
  put-function --name ping --wasm-file ../wasm/web_function.wasm
# Function uploaded or updated! Name: ping, ID: f-asdfljsdf, Version: 16

cargo run -q -- preview function \
  invoke-function --name ping
# pong

cargo run -q -- preview function list-functions
# Name: ping, ID: f-asdfljsdf, Latest Version: 16, Current Version: 16, Description: , Last Uploaded: 2026-04-16T18:43:26.354833459+00:00
```

## Sample Misuse

**`clap` errors:**

```bash
cargo run -q -- preview function \
  put-function-config --name ping --use-latest-version --pin-version 3
# error: the argument '--use-latest-version' cannot be used with '--pin-version <VERSION>'

cargo run -q -- preview function \
  put-function-config --name ping
# error: the following required arguments were not provided:
#  <--pin-version <VERSION>|--use-latest-version>

cargo run -q -- preview function \
  put-function-config --name ping --pin-version -1
# error: unexpected argument '-1' found
# Usage: momento preview function put-function-config [OPTIONS] <--name <FUNCTION>|--id <FUNCTION>> <--pin-version <VERSION>|--use-latest-version>
```

**SDK errors:**

```bash
cargo run -q -- preview function \
  put-function-config --name hi-i-dont-exist --use-latest-version
# ERROR: MomentoError { message: "A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it", error_code: CacheNotFoundError, inner_error: Some(TonicStatus(Status { code: NotFound, message: "function doesn't exist", ... })) }

cargo run -q -- preview function \
  put-function-config --name ping --pin-version 999999999
# ERROR: MomentoError { message: "A cache with the specified name does not exist.  To resolve this error, make sure you have created the cache before attempting to use it", error_code: CacheNotFoundError, inner_error: Some(TonicStatus(Status { code: NotFound, message: "version 999999999 doesn't exist for this function", ... })) }
```

Notes:
- When a function or version doesn't exist, the SDK maps this to `CacheNotFound`. This needs to be fixed, but I feel it's better suited to be its own set of PRs. I'm also working on shortening / clarifying `MomentoError`s in (as of this writing) [#367](https://github.com/momentohq/momento-cli/pull/367).