### PR TITLE
feat: list `FunctionVersion` descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.64.0"
+version = "0.64.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624e81f8d253799a935bad323f530cd6851d4d370b7f8c32daebd793914a4b83"
+checksum = "43706f990cedd4ede9207a85ef4dc3166154070df5a9b09a741c550c56cd9865"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -2453,9 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.130.0"
+version = "0.130.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64297cbc2d3946a4a64365db65cdfb6df6c65fec66af7bfa3a3cc71da94b6a11"
+checksum = "e522903f13088da517d053096450fdd8073f889674e0490ba479118607f88282"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,7 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.63.0"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624e81f8d253799a935bad323f530cd6851d4d370b7f8c32daebd793914a4b83"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -2451,7 +2453,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.1.0"
+version = "0.130.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64297cbc2d3946a4a64365db65cdfb6df6c65fec66af7bfa3a3cc71da94b6a11"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,8 +2378,6 @@ dependencies = [
 [[package]]
 name = "momento"
 version = "0.63.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ab846d102b57272d0da158fd532d9ed72280e00045b0c0491ead04ea9171d8"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -2453,9 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.129.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da49420d6a1e070d54831d9ed72af16e08f3e67850df566c9f6a6409f29ae62"
+version = "0.1.0"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -43,7 +43,7 @@ features = [ "macros",]
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-version = "0.63.0"
+path = "../../client-sdk-rust"
 
 [dependencies.futures]
 version = "0.3.28"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -43,7 +43,7 @@ features = [ "macros",]
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-path = "../../client-sdk-rust"
+version = "0.64.0"
 
 [dependencies.futures]
 version = "0.3.28"

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -43,7 +43,7 @@ features = [ "macros",]
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-version = "0.64.0"
+version = "0.64.1"
 
 [dependencies.futures]
 version = "0.3.28"

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -153,22 +153,14 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
         console_data!("No functions found in cache namespace: {cache_name}");
     } else {
         console_data!("Functions in cache namespace: {cache_name}");
-        console_data!("To see all your descriptions, list-function-versions instead."); // TODO remove this note when we have fully migrated to FunctionVersion descriptions
         functions_list.iter().for_each(|function| {
-            let description = if function.latest_version() == function.version()
-                && !function.description().is_empty()
-            {
-                format!(", Description: \"{}\"", function.description())
-            } else {
-                "".to_string()
-            };
             console_data!(
-                "\nName: {}, ID: {}, Latest Version: {}, Current Version: {}{}, Last Uploaded: {}",
+                "\nName: {}, ID: {}, Latest Version: {}, Current Version: {}, Description: \"{}\", Last Uploaded: {}",
                 function.name(),
                 function.function_id(),
                 function.latest_version(),
                 function.version(),
-                description, // TODO remove the Function description when we have fully migrated to FunctionVersion descriptions
+                function.description(),
                 function.last_updated_at(),
             )
         });

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -153,14 +153,15 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
         console_data!("No functions found in cache namespace: {cache_name}");
     } else {
         console_data!("Functions in cache namespace: {cache_name}");
+        console_data!("To see all your descriptions, list-function-versions instead."); // TODO remove this note when we have fully migrated to FunctionVersion descriptions
         functions_list.iter().for_each(|function| {
             let description = if function.latest_version() == function.version() && !function.description().is_empty() {
-                function.description()
+                format!(", Description: {}", function.description())
             } else {
-                "N/A (List versions to see description)"
+                "".to_string()
             };
             console_data!(
-                "Name: {}, ID: {}, Latest Version: {}, Current Version: {}, Description: {}, Last Uploaded: {}",
+                "- Name: {}, ID: {}, Latest Version: {}, Current Version: {}{}, Last Uploaded: {}",
                 function.name(),
                 function.function_id(),
                 function.latest_version(),

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -155,7 +155,9 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
         console_data!("Functions in cache namespace: {cache_name}");
         console_data!("To see all your descriptions, list-function-versions instead."); // TODO remove this note when we have fully migrated to FunctionVersion descriptions
         functions_list.iter().for_each(|function| {
-            let description = if function.latest_version() == function.version() && !function.description().is_empty() {
+            let description = if function.latest_version() == function.version()
+                && !function.description().is_empty()
+            {
                 format!(", Description: {}", function.description())
             } else {
                 "".to_string()

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -163,7 +163,7 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
                 "".to_string()
             };
             console_data!(
-                "- Name: {}, ID: {}, Latest Version: {}, Current Version: {}{}, Last Uploaded: {}",
+                "\nName: {}, ID: {}, Latest Version: {}, Current Version: {}{}, Last Uploaded: {}",
                 function.name(),
                 function.function_id(),
                 function.latest_version(),
@@ -190,7 +190,7 @@ pub async fn list_function_versions(
         console_data!("Versions for function: {function_id}");
         function_versions_list.iter().for_each(|version| {
             console_data!(
-                "Function Version: {}, Description: {}, Wasm ID: {}, Wasm Version: {}, Environment Variables: {:#?}",
+                "\nFunction Version: {}, Description: {}, Wasm ID: {}, Wasm Version: {}, Environment Variables: {:#?}",
                 version.version_id().version(),
                 version.description(),
                 version.wasm_version_id().id(),

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -158,7 +158,7 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
             let description = if function.latest_version() == function.version()
                 && !function.description().is_empty()
             {
-                format!(", Description: {}", function.description())
+                format!(", Description: \"{}\"", function.description())
             } else {
                 "".to_string()
             };
@@ -190,7 +190,7 @@ pub async fn list_function_versions(
         console_data!("Versions for function: {function_id}");
         function_versions_list.iter().for_each(|version| {
             console_data!(
-                "\nFunction Version: {}, Description: {}, Wasm ID: {}, Wasm Version: {}, Environment Variables: {:#?}",
+                "\nFunction Version: {}, Description: \"{}\", Wasm ID: {}, Wasm Version: {}, Environment Variables: {:#?}",
                 version.version_id().version(),
                 version.description(),
                 version.wasm_version_id().id(),

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -154,13 +154,18 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
     } else {
         console_data!("Functions in cache namespace: {cache_name}");
         functions_list.iter().for_each(|function| {
+            let description = if function.latest_version() == function.version() && !function.description().is_empty() {
+                function.description()
+            } else {
+                "N/A (List versions to see description)"
+            };
             console_data!(
                 "Name: {}, ID: {}, Latest Version: {}, Current Version: {}, Description: {}, Last Uploaded: {}",
                 function.name(),
                 function.function_id(),
                 function.latest_version(),
                 function.version(),
-                function.description(),
+                description, // TODO remove the Function description when we have fully migrated to FunctionVersion descriptions
                 function.last_updated_at(),
             )
         });
@@ -182,8 +187,9 @@ pub async fn list_function_versions(
         console_data!("Versions for function: {function_id}");
         function_versions_list.iter().for_each(|version| {
             console_data!(
-                "Function Version: {}, Wasm ID: {}, Wasm Version: {}, Environment Variables: {:#?}",
+                "Function Version: {}, Description: {}, Wasm ID: {}, Wasm Version: {}, Environment Variables: {:#?}",
                 version.version_id().version(),
+                version.description(),
                 version.wasm_version_id().id(),
                 version.wasm_version_id().version(),
                 version.environment()


### PR DESCRIPTION
In this PR, `list-function-versions` now outputs every `FunctionVersion`'s description. `list-functions` outputs the current/active `Function` description, whether latest or pinned.

## Sample Outputs

### 

```bash
momento preview function put-function --name ping --wasm-file ../wasm/web_function.wasm \
  --env-var "hello=world"
momento preview function put-function --name ping --wasm-file ../wasm/web_function.wasm \
  --description "this function has only a description, no environment variables"

momento preview function put-function-config --name ping --pin-version 1

momento preview function put-function --name ping --wasm-file ../wasm/web_function.wasm \
  --description "this function has a description AND an environment variable" --env-var "foo=bar"
```

### Listing function versions:

```bash
cargo run -q -- preview function list-function-versions --id $FUNCTION_ID
```
```
Versions for function: f-abcdefg

Function Version: 0, Description: "", Wasm ID: w-gfedcba, Wasm Version: 0, Environment Variables: {
    "hello": Literal(
        "world",
    ),
}

Function Version: 1, Description: "this function has only a description, no environment variables", Wasm ID: w-fedcbag, Wasm Version: 0, Environment Variables: {}

Function Version: 2, Description: "this function has a description AND an environment variable", Wasm ID: w-edcbagf, Wasm Version: 0, Environment Variables: {
    "foo": Literal(
        "bar",
    ),
}
```

### Listing functions:

```bash
cargo run -q -- preview function list-functions
```
```
Functions in cache namespace: default-cache

Name: ping, ID: f-abcdefg, Latest Version: 2, Current Version: 1, Description: "this function has only a description, no environment variables", Last Uploaded: 2026-04-23T21:07:51.646086801+00:00
```