### PR TITLE
feat: configure function CloudWatch metrics delivery from the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "momento"
-version = "0.64.1"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43706f990cedd4ede9207a85ef4dc3166154070df5a9b09a741c550c56cd9865"
+checksum = "cc8c2b85f993cb7ba74c8ac89f67e77627efba858fa2b2f2a9684531e368572c"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -2452,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "momento-protos"
-version = "0.130.1"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e522903f13088da517d053096450fdd8073f889674e0490ba479118607f88282"
+checksum = "c5cdb80e6857610decc80ff9473e889aad71e1aa3b7bf37df73472e88bb99cc9"
 dependencies = [
  "prost",
  "protosocket-rpc",

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -199,6 +199,28 @@ pub enum FunctionCommand {
             value_name = "WASM"
         )]
         environment_variables: Vec<(String, String)>,
+        #[arg(
+            long = "metrics-iam-role",
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Deliver this function's metrics to your own CloudWatch account using this IAM role. Overrides your account-wide default for just this function",
+            value_name = "IAM_ROLE",
+            group = "function-metrics"
+        )]
+        metrics_iam_role: Option<String>,
+        #[arg(
+            long = "disable-metrics",
+            help = "Disable delivery of this function's metrics to your CloudWatch account. Overrides your account-wide default for just this function",
+            default_value_t = false,
+            group = "function-metrics"
+        )]
+        disable_metrics: bool,
+        #[arg(
+            long = "remove-metrics-config",
+            help = "Remove this function's metrics configuration so it follows your account-wide default",
+            default_value_t = false,
+            group = "function-metrics"
+        )]
+        remove_metrics_config: bool,
     },
     #[command(
     about = "Update a Momento Function's configuration",
@@ -208,8 +230,10 @@ pub enum FunctionCommand {
     .args(["function_name", "function_id"]),
     ),
     group(
+    // Not required: a config update may change only the version, only the metrics
+    // configuration, or both. At least one is enforced at runtime.
     clap::ArgGroup::new("version")
-    .required(true)
+    .required(false)
     .args(["pin_version", "use_latest_version"]),
     ),
     )]
@@ -252,6 +276,29 @@ pub enum FunctionCommand {
             default_value_t = false
         )]
         use_latest_version: bool,
+
+        #[arg(
+            long = "metrics-iam-role",
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Deliver this function's metrics to your own CloudWatch account using this IAM role. Overrides your account-wide default for just this function",
+            value_name = "IAM_ROLE",
+            group = "function-metrics"
+        )]
+        metrics_iam_role: Option<String>,
+        #[arg(
+            long = "disable-metrics",
+            help = "Disable delivery of this function's metrics to your CloudWatch account. Overrides your account-wide default for just this function",
+            default_value_t = false,
+            group = "function-metrics"
+        )]
+        disable_metrics: bool,
+        #[arg(
+            long = "remove-metrics-config",
+            help = "Remove this function's metrics configuration so it follows your account-wide default",
+            default_value_t = false,
+            group = "function-metrics"
+        )]
+        remove_metrics_config: bool,
     },
     #[command(about = "Create or update a Wasm source that can be used in a Momento Function")]
     PutWasm {

--- a/momento/Cargo.toml
+++ b/momento/Cargo.toml
@@ -43,7 +43,7 @@ features = [ "macros",]
 path = "../momento-cli-opts"
 
 [dependencies.momento]
-version = "0.64.1"
+version = "0.66.0"
 
 [dependencies.futures]
 version = "0.3.28"

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -1,14 +1,16 @@
 use momento::{
     functions::{
-        CurrentFunctionVersion, ListFunctionVersionsRequest, ListFunctionsRequest,
-        ListWasmsRequest, PutFunctionConfigRequest, PutFunctionRequest, PutWasmRequest, WasmSource,
+        CurrentFunctionVersion, FunctionMetricsConfigChange, ListFunctionVersionsRequest,
+        ListFunctionsRequest, ListWasmsRequest, PutFunctionConfigRequest, PutFunctionRequest,
+        PutWasmRequest, WasmSource,
     },
     FunctionClient,
 };
 
 use crate::{
     commands::functions::utils::{
-        build_invocation_headers, build_invocation_url, read_wasm_file, InvocationOptions,
+        build_invocation_headers, build_invocation_url, format_metrics_config, read_wasm_file,
+        InvocationOptions,
     },
     error::CliError,
     utils::console::console_data,
@@ -34,29 +36,36 @@ pub async fn put_function(
     wasm_source: WasmSource,
     description: Option<String>,
     environment_variables: Vec<(String, String)>,
+    metrics_change: Option<FunctionMetricsConfigChange>,
 ) -> Result<(), CliError> {
     let mut request = PutFunctionRequest::new(&cache_name, &name, wasm_source);
     if let Some(description) = description {
         request = request.description(description);
     }
     request = request.environment(environment_variables);
+    if let Some(metrics_change) = metrics_change {
+        request = request.metrics_config(metrics_change);
+    }
     let response = client.send(request).await.map_err(Into::<CliError>::into)?;
     let uploaded_version = response.latest_version();
     let current_version = response.version();
+    let metrics = format_metrics_config(response.metrics_config());
     if uploaded_version == current_version {
         console_data!(
-            "Function uploaded or updated! Name: {}, ID: {}, Version: {}",
+            "Function uploaded or updated! Name: {}, ID: {}, Version: {}, Metrics: {}",
             response.name(),
             response.function_id(),
             uploaded_version,
+            metrics,
         );
     } else {
         console_data!(
-        "Function version uploaded but not in use. Name: {}, ID: {}, Latest Version: {}, Current Version: {}",
+        "Function version uploaded but not in use. Name: {}, ID: {}, Latest Version: {}, Current Version: {}, Metrics: {}",
         response.name(),
         response.function_id(),
         uploaded_version,
         current_version,
+        metrics,
     );
     }
     Ok(())
@@ -68,7 +77,14 @@ pub async fn put_function_config(
     function_name: Option<String>,
     function_id: Option<String>,
     new_version: Option<CurrentFunctionVersion>,
+    metrics_change: Option<FunctionMetricsConfigChange>,
 ) -> Result<(), CliError> {
+    if new_version.is_none() && metrics_change.is_none() {
+        return Err(CliError::new(
+            "Specify a version (--pin-version or --use-latest-version) and/or a metrics configuration change (--metrics-iam-role, --disable-metrics, or --remove-metrics-config) to update",
+        ));
+    }
+
     let mut request = if let Some(name) = function_name {
         PutFunctionConfigRequest::from_function_name(&cache_name, &name)
     } else if let Some(id) = function_id {
@@ -80,14 +96,18 @@ pub async fn put_function_config(
     if let Some(new_version) = new_version {
         request = request.current_version(new_version);
     }
+    if let Some(metrics_change) = metrics_change {
+        request = request.metrics_config(metrics_change);
+    }
 
     let response = client.send(request).await.map_err(Into::<CliError>::into)?;
     console_data!(
-        "Function config updated! Name: {}, ID: {}, Latest Version: {}, Current Version: {}",
+        "Function config updated! Name: {}, ID: {}, Latest Version: {}, Current Version: {}, Metrics: {}",
         response.name(),
         response.function_id(),
         response.latest_version(),
         response.version(),
+        format_metrics_config(response.metrics_config()),
     );
     Ok(())
 }
@@ -157,13 +177,14 @@ pub async fn list_functions(client: FunctionClient, cache_name: String) -> Resul
         console_data!("Functions in cache namespace: {cache_name}");
         functions_list.iter().for_each(|function| {
             console_data!(
-                "\nName: {}, ID: {}, Latest Version: {}, Current Version: {}, Description: \"{}\", Last Uploaded: {}",
+                "\nName: {}, ID: {}, Latest Version: {}, Current Version: {}, Description: \"{}\", Last Uploaded: {}, Metrics: {}",
                 function.name(),
                 function.function_id(),
                 function.latest_version(),
                 function.version(),
                 function.description(),
                 function.last_updated_at(),
+                format_metrics_config(function.metrics_config()),
             )
         });
     }

--- a/momento/src/commands/functions/utils.rs
+++ b/momento/src/commands/functions/utils.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::fs;
 use std::str::FromStr; // to use HeaderName::from_str
 
-use momento::functions::{CurrentFunctionVersion, WasmSource};
+use momento::functions::{
+    CurrentFunctionVersion, FunctionMetricsConfig, FunctionMetricsConfigChange, WasmSource,
+};
 
 use crate::error::CliError;
 
@@ -47,6 +49,39 @@ pub fn determine_current_function_version(
         Some(CurrentFunctionVersion::Latest)
     } else {
         pin_version.map(CurrentFunctionVersion::Pinned)
+    }
+}
+
+/// put-function / put-function-config
+///
+/// Resolves the mutually-exclusive metrics flags into a change to apply to the function's
+/// metrics configuration, or `None` when no metrics flag was provided (leave it unchanged).
+/// The flags are mutually exclusive at the CLI layer, so at most one is set here.
+pub fn determine_metrics_config_change(
+    metrics_iam_role: Option<String>,
+    disable_metrics: bool,
+    remove_metrics_config: bool,
+) -> Option<FunctionMetricsConfigChange> {
+    if remove_metrics_config {
+        Some(FunctionMetricsConfigChange::Remove)
+    } else if disable_metrics {
+        Some(FunctionMetricsConfigChange::Set(
+            FunctionMetricsConfig::Disabled,
+        ))
+    } else {
+        metrics_iam_role
+            .map(|role| FunctionMetricsConfigChange::Set(FunctionMetricsConfig::enabled(role)))
+    }
+}
+
+/// Renders a function's resolved metrics configuration for display.
+pub fn format_metrics_config(metrics_config: Option<&FunctionMetricsConfig>) -> String {
+    match metrics_config {
+        None => "none (follows account-wide default)".to_string(),
+        Some(FunctionMetricsConfig::Disabled) => "disabled".to_string(),
+        Some(FunctionMetricsConfig::Enabled { customer_iam_role }) => {
+            format!("enabled (IAM role: {customer_iam_role})")
+        }
     }
 }
 

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -15,7 +15,8 @@ use utils::{
 
 use crate::{
     commands::functions::utils::{
-        determine_current_function_version, determine_wasm_source, InvocationOptions,
+        determine_current_function_version, determine_metrics_config_change, determine_wasm_source,
+        InvocationOptions,
     },
     utils::console::console_info,
 };
@@ -242,6 +243,9 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         version_uploaded_wasm,
                         description,
                         environment_variables,
+                        metrics_iam_role,
+                        disable_metrics,
+                        remove_metrics_config,
                     } => {
                         let cache_name = cache_name.unwrap_or(config.cache);
                         let wasm_source = determine_wasm_source(
@@ -249,6 +253,11 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                             id_uploaded_wasm,
                             version_uploaded_wasm,
                         )?;
+                        let metrics_change = determine_metrics_config_change(
+                            metrics_iam_role,
+                            disable_metrics,
+                            remove_metrics_config,
+                        );
                         commands::functions::function_cli::put_function(
                             client,
                             cache_name,
@@ -256,6 +265,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                             wasm_source,
                             description,
                             environment_variables,
+                            metrics_change,
                         )
                         .await?
                     }
@@ -265,16 +275,25 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         function_id,
                         pin_version,
                         use_latest_version,
+                        metrics_iam_role,
+                        disable_metrics,
+                        remove_metrics_config,
                     } => {
                         let cache_name = cache_name.unwrap_or(config.cache);
                         let new_version =
                             determine_current_function_version(pin_version, use_latest_version);
+                        let metrics_change = determine_metrics_config_change(
+                            metrics_iam_role,
+                            disable_metrics,
+                            remove_metrics_config,
+                        );
                         commands::functions::function_cli::put_function_config(
                             client,
                             cache_name,
                             function_name,
                             function_id,
                             new_version,
+                            metrics_change,
                         )
                         .await?
                     }


### PR DESCRIPTION
Adds the ability for users to explicitly enable, disable, or remove a configuration for emitting metrics related to their functions to their CloudWatch account