### PR TITLE
fix: rename asset for brew version parsing

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -112,7 +112,11 @@ jobs:
       - name: Build tar.gz and publish asset
         run: |
           VERSION=${{ needs.release.outputs.version }}
-          ARCHIVE_FILE="momento-cli-$VERSION.linux_${{ matrix.architecture.rpm-arch-shortname }}.tar.gz"
+          # Name must be "momento-cli-<version>-<rust-triple>.tar.gz". Homebrew scans
+          # the version out of this filename on brew releases that lack the GitHub
+          # release-tag parser; "0.56.2.linux_x86_64" scans as "86.64" and breaks
+          # bottle lookup for every customer. Do not reintroduce "." or "linux_".
+          ARCHIVE_FILE="momento-cli-$VERSION-${{ matrix.architecture.target }}.tar.gz"
           BUILD_OUTPUT_DIR="./target/${{ matrix.architecture.target }}/release/"
           mkdir $BUILD_OUTPUT_DIR/bash
           cp $BUILD_OUTPUT_DIR/momento.bash $BUILD_OUTPUT_DIR/bash/momento
@@ -234,7 +238,10 @@ jobs:
       - name: Build tar.gz and publish asset
         run: |
           VERSION=${{ needs.release.outputs.version }}
-          ARCHIVE_FILE="momento-cli-$VERSION.${{ matrix.architecture.target }}.tar.gz"
+          # Name must be "momento-cli-<version>-<rust-triple>.tar.gz" -- see the note
+          # in publish-linux-assets. "0.56.2.aarch64-apple-darwin" scans as
+          # "0.56.2.aarch64" and breaks bottle lookup. Do not reintroduce the ".".
+          ARCHIVE_FILE="momento-cli-$VERSION-${{ matrix.architecture.target }}.tar.gz"
           BUILD_OUTPUT_DIR="./target/${{ matrix.architecture.target }}/release/"
           mkdir $BUILD_OUTPUT_DIR/bash
           cp $BUILD_OUTPUT_DIR/momento.bash $BUILD_OUTPUT_DIR/bash/momento
@@ -523,10 +530,12 @@ jobs:
           echo "Version is $MOMENTO_CLI_VERSION"
           git checkout -b formula/momento-cli/v${MOMENTO_CLI_VERSION}
           
-          export MOMENTO_CLI_LINUX_X86_64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}.linux_x86_64.tar.gz"
-          export MOMENTO_CLI_LINUX_AARCH64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}.linux_aarch64.tar.gz"
-          export MOMENTO_CLI_MAC_X86_64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}.x86_64-apple-darwin.tar.gz"
-          export MOMENTO_CLI_MAC_AARCH64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}.aarch64-apple-darwin.tar.gz"
+          # These must match the ARCHIVE_FILE names built above, and must keep the
+          # "-<rust-triple>" form so Homebrew scans the version correctly.
+          export MOMENTO_CLI_LINUX_X86_64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          export MOMENTO_CLI_LINUX_AARCH64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+          export MOMENTO_CLI_MAC_X86_64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}-x86_64-apple-darwin.tar.gz"
+          export MOMENTO_CLI_MAC_AARCH64_URL="https://github.com/momentohq/momento-cli/releases/download/v${MOMENTO_CLI_VERSION}/momento-cli-${MOMENTO_CLI_VERSION}-aarch64-apple-darwin.tar.gz"
           
           echo "Downloading and computing SHA for ${MOMENTO_CLI_LINUX_X86_64_URL}"
           wget ${MOMENTO_CLI_LINUX_X86_64_URL} -O linux-x86_64.tgz

--- a/README.ja.md
+++ b/README.ja.md
@@ -33,7 +33,7 @@ momento cache get key --cache example-cache
 ### Linux
 
 1. 最新の linux tar.gz ファイルを[https://github.com/momentohq/momento-cli/releases/latest](https://github.com/momentohq/momento-cli/releases/latest)からダウンロードする。
-2. `tar -xvf momento-cli-X.X.X.linux_x86_64.tar.gz`ファイルを展開する。
+2. `tar -xvf momento-cli-X.X.X-x86_64-unknown-linux-gnu.tar.gz`ファイルを展開する。
 3. `./momento`を実行パスに置く。
 
 ### Windows


### PR DESCRIPTION
## Problem

  `brew install momentohq/tap/momento-cli` failing with:

      Pouring momento-cli-0.56.2.aarch64.arm64_sequoia.bottle.tar.gz
      Error: No such file or directory

  ## Root cause
  
  Our release assets put a `.` before the arch (`momento-cli-0.56.2.aarch64-apple-darwin.tar.gz`).
  The tap formula has no `version` stanza, so Homebrew scans the version out of the URL —
  and mis-parses every one of our names:

  | asset name | scans as |
  | --- | --- |
  | `momento-cli-0.56.2.aarch64-apple-darwin.tar.gz` | `0.56.2.aarch64` |
  | `momento-cli-0.56.2.x86_64-apple-darwin.tar.gz` | `0.56.2.x86_64` |
  | `momento-cli-0.56.2.linux_x86_64.tar.gz` | `86.64` |
  | `momento-cli-0.56.2.linux_aarch64.tar.gz` | `64` |

  brew then requests a bottle named `momento-cli-0.56.2.aarch64.arm64_sequoia.bottle.tar.gz`
  (404) and expects `Cellar/momento-cli/0.56.2.aarch64`, while the published bottle is
  `momento-cli-0.56.2.arm64_sequoia.bottle.tar.gz` unpacking to `momento-cli/0.56.2` — so the
  install dies at the pour step.

  Homebrew added a parser that reads the version from the GitHub release tag instead
  (Homebrew/brew@bae7b040), which masks the bug — but it is not in any released tag yet, and
  normal users update to tags, not main. Our tap CI uses `setup-homebrew@master`, so CI runs
  the fixed parser and stays green while customers break. Adding `version` back to the formula
  is not viable: it fails `brew audit` as redundant once that parser ships.

  `mo` was never affected because its assets already use the `-<triple>` form.

  ## Fix

  Rename release assets to `momento-cli-<version>-<rust-triple>.tar.gz`, matching `mo`:

  - `publish-linux-assets`: use `matrix.architecture.target` instead of `rpm-arch-shortname`
    (`-x86_64-unknown-linux-gnu`, not `.linux_x86_64` — a separator swap alone is not enough,
    `linux_x86_64` still scans as `86.64`)
  - `publish-mac-assets`: `.` -> `-` before the triple
  - `update-homebrew-formula`: the four URL exports updated to match

  rpm/deb naming is unchanged (`rpm-arch-shortname` is still used there; Homebrew does not
  consume those). No change needed in homebrew-tap — the formula template just interpolates
  these URLs.