### PR TITLE
feat: capacity pools & databases

### DIFF
--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -435,7 +435,14 @@ pub enum CapacityPoolCommand {
         )]
         name: String,
     },
-    #[command(about = "Update a Momento capacity pool")]
+    #[command(
+    about = "Update a Momento capacity pool",
+    group(
+    clap::ArgGroup::new("field")
+    .required(true)
+    .multiple(true)
+    ),
+    )]
     UpdatePool {
         #[arg(
             long,
@@ -447,17 +454,20 @@ pub enum CapacityPoolCommand {
         name: String,
         #[arg(
             long,
-            help = "New EC2 instance type for the backing cluster; omit to leave unchanged"
+            help = "New EC2 instance type for the backing cluster; omit to leave unchanged",
+            group = "field"
         )]
         instance_type: Option<String>,
         #[arg(
             long,
-            help = "New shard count for the backing cluster; omit to leave unchanged"
+            help = "New shard count for the backing cluster; omit to leave unchanged",
+            group = "field"
         )]
         shard_count: Option<u32>,
         #[arg(
             long,
-            help = "New replicas per shard — a single value (e.g. 2); omit to leave unchanged"
+            help = "New replicas per shard — a single value (e.g. 2); omit to leave unchanged",
+            group = "field"
         )]
         replicas_per_shard: Option<u32>,
         #[arg(
@@ -466,7 +476,8 @@ pub enum CapacityPoolCommand {
             value_delimiter = ',',
             help = "Replace the zone set with these AZ IDs, e.g. usw2-az1 (comma-delimited) — \
                     ids, not names like us-west-2a; omit to leave unchanged",
-            value_name = "AVAILABILITY_ZONES"
+            value_name = "AVAILABILITY_ZONES",
+            group = "field"
         )]
         zones: Option<Vec<String>>,
     },

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -396,29 +396,30 @@ pub enum FunctionCommand {
 }
 
 #[derive(Debug, Parser)]
-pub enum PoolCommand {
+pub enum CapacityPoolCommand {
     #[command(about = "Create a Momento capacity pool")]
     CreatePool {
         #[arg(
             long,
-            short,
+            short = 'n',
             value_parser = NonEmptyStringValueParser::new(),
             help = "Name of the capacity pool you want to create",
             value_name = "POOL"
         )]
         name: String,
-        #[arg(long, help = "Instance type")]
+        #[arg(long, help = "EC2 instance type backing the pool's cluster")]
         instance_type: String,
-        #[arg(long, help = "Shard count")]
+        #[arg(long, help = "Number of shards in the backing cluster")]
         shard_count: u32,
-        #[arg(long, help = "Replicas per shard")]
+        #[arg(long, help = "Replicas per shard — a single value (e.g. 2)")]
         replicas_per_shard: u32,
         #[arg(
             long,
-            help = "Availability zone IDs",
             required = true,
             num_args = 1..,
             value_delimiter = ',',
+            help = "Availability zone IDs for the backing cluster, e.g. usw2-az1 (comma-delimited) — \
+                    ids, not names like us-west-2a",
             value_name = "AVAILABILITY_ZONES"
         )]
         zones: Vec<String>,
@@ -444,17 +445,27 @@ pub enum PoolCommand {
             value_name = "POOL"
         )]
         name: String,
-        #[arg(long, help = "Instance type")]
+        #[arg(
+            long,
+            help = "New EC2 instance type for the backing cluster; omit to leave unchanged"
+        )]
         instance_type: Option<String>,
-        #[arg(long, help = "Shard count")]
+        #[arg(
+            long,
+            help = "New shard count for the backing cluster; omit to leave unchanged"
+        )]
         shard_count: Option<u32>,
-        #[arg(long, help = "Replicas per shard")]
+        #[arg(
+            long,
+            help = "New replicas per shard — a single value (e.g. 2); omit to leave unchanged"
+        )]
         replicas_per_shard: Option<u32>,
         #[arg(
             long,
-            help = "Availability zone IDs",
             num_args = 1..,
             value_delimiter = ',',
+            help = "Replace the zone set with these AZ IDs, e.g. usw2-az1 (comma-delimited) — \
+                    ids, not names like us-west-2a; omit to leave unchanged",
             value_name = "AVAILABILITY_ZONES"
         )]
         zones: Option<Vec<String>>,
@@ -467,16 +478,16 @@ pub enum DatabaseCommand {
     CreateDatabase {
         #[arg(
             long,
-            short,
+            short = 'n',
             value_parser = NonEmptyStringValueParser::new(),
             help = "Name of the database you want to create",
             value_name = "DATABASE"
         )]
-        name: String,
+        database_name: String,
         #[arg(
             long,
             value_parser = NonEmptyStringValueParser::new(),
-            help = "Name of the capacity pool to pin your database to",
+            help = "Name of the capacity pool to pin the database to",
             value_name = "POOL"
         )]
         pool_name: String,
@@ -596,7 +607,7 @@ https://github.com/momentohq/functions/"
         endpoint: Option<String>,
 
         #[command(subcommand)]
-        operation: PoolCommand,
+        operation: CapacityPoolCommand,
     },
     #[command(about = "**PREVIEW** Interact with your Momento databases")]
     Database {

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -531,6 +531,19 @@ pub enum CapacityPoolCommand {
         )]
         zones: Vec<String>,
     },
+    #[command(about = "Delete a Momento capacity pool")]
+    DeletePool {
+        #[arg(
+            long,
+            short,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the capacity pool you want to delete",
+            value_name = "POOL"
+        )]
+        name: String,
+    },
+    #[command(about = "List all your Momento capacity pools")]
+    ListPools {},
 }
 
 #[derive(Debug, Parser)]
@@ -553,6 +566,19 @@ pub enum DatabaseCommand {
         )]
         pool_name: String,
     },
+    #[command(about = "Delete a Momento database")]
+    DeleteDatabase {
+        #[arg(
+            long,
+            short = 'n',
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the database you want to delete",
+            value_name = "DATABASE"
+        )]
+        database_name: String,
+    },
+    #[command(about = "List all your Momento databases")]
+    ListDatabases {},
 }
 
 #[derive(Debug, Parser)]

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -396,6 +396,94 @@ pub enum FunctionCommand {
 }
 
 #[derive(Debug, Parser)]
+pub enum PoolCommand {
+    #[command(about = "Create a Momento capacity pool")]
+    CreatePool {
+        #[arg(
+            long,
+            short,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the capacity pool you want to create",
+            value_name = "POOL"
+        )]
+        name: String,
+        #[arg(long, help = "Instance type")]
+        instance_type: String,
+        #[arg(long, help = "Shard count")]
+        shard_count: u32,
+        #[arg(long, help = "Replicas per shard")]
+        replicas_per_shard: u32,
+        #[arg(
+            long,
+            help = "Availability zone IDs",
+            required = true,
+            num_args = 1..,
+            value_delimiter = ',',
+            value_name = "AVAILABILITY_ZONES"
+        )]
+        zones: Vec<String>,
+    },
+    #[command(about = "Get your capacity pool's lifecycle status")]
+    GetStatus {
+        #[arg(
+            long,
+            short,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the capacity pool you want to describe",
+            value_name = "POOL"
+        )]
+        name: String,
+    },
+    #[command(about = "Update a Momento capacity pool")]
+    UpdatePool {
+        #[arg(
+            long,
+            short,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the capacity pool you want to update",
+            value_name = "POOL"
+        )]
+        name: String,
+        #[arg(long, help = "Instance type")]
+        instance_type: Option<String>,
+        #[arg(long, help = "Shard count")]
+        shard_count: Option<u32>,
+        #[arg(long, help = "Replicas per shard")]
+        replicas_per_shard: Option<u32>,
+        #[arg(
+            long,
+            help = "Availability zone IDs",
+            num_args = 1..,
+            value_delimiter = ',',
+            value_name = "AVAILABILITY_ZONES"
+        )]
+        zones: Option<Vec<String>>,
+    },
+}
+
+#[derive(Debug, Parser)]
+pub enum DatabaseCommand {
+    #[command(about = "Create a Momento database")]
+    CreateDatabase {
+        #[arg(
+            long,
+            short,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the database you want to create",
+            value_name = "DATABASE"
+        )]
+        name: String,
+        #[arg(
+            long,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "Name of the capacity pool to pin your database to",
+            value_name = "POOL"
+        )]
+        pool_name: String,
+    },
+}
+
+#[derive(Debug, Parser)]
 pub enum PreviewCommand {
     #[command(
         about = "**PREVIEW** Query your AWS account to find optimizations with Momento",
@@ -487,6 +575,50 @@ https://github.com/momentohq/functions/"
 
         #[command(subcommand)]
         operation: FunctionCommand,
+    },
+    #[command(about = "**PREVIEW** Interact with your Momento capacity pools")]
+    Pool {
+        #[arg(
+            long,
+            global = true,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "An explicit Momento API key to use [default: your profile's API key]"
+        )]
+        api_key: Option<String>,
+
+        #[arg(
+            long,
+            short,
+            global = true,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "An explicit hostname to use. Example: cell-us-east-1-1.prod.a.momentohq.com"
+        )]
+        endpoint: Option<String>,
+
+        #[command(subcommand)]
+        operation: PoolCommand,
+    },
+    #[command(about = "**PREVIEW** Interact with your Momento databases")]
+    Database {
+        #[arg(
+            long,
+            global = true,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "An explicit Momento API key to use [default: your profile's API key]"
+        )]
+        api_key: Option<String>,
+
+        #[arg(
+            long,
+            short,
+            global = true,
+            value_parser = NonEmptyStringValueParser::new(),
+            help = "An explicit hostname to use. Example: cell-us-east-1-1.prod.a.momentohq.com"
+        )]
+        endpoint: Option<String>,
+
+        #[command(subcommand)]
+        operation: DatabaseCommand,
     },
 }
 

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -437,10 +437,10 @@ pub enum CapacityPoolCommand {
             long,
             group = "mode",
             value_parser = parse_positive_bounds,
-            help = "Managed mode: capacity bounds in GB — `500` pins, \
+            help = "Managed mode: capacity bounds in GiB — `500` pins, \
                     `100..500` lets Momento auto-scale within the range"
         )]
-        capacity_gb: Option<Bounds>,
+        capacity_gib: Option<Bounds>,
         #[arg(
             long,
             required = true,
@@ -513,12 +513,12 @@ pub enum CapacityPoolCommand {
         #[arg(
             long,
             value_parser = parse_positive_bounds,
-            help = "Managed mode: new capacity bounds in GB — `500` pins, \
+            help = "Managed mode: new capacity bounds in GiB — `500` pins, \
                    `100..500` lets Momento auto-scale within the range; \
                     omit to leave unchanged",
             group = "field"
         )]
-        capacity_gb: Option<Bounds>,
+        capacity_gib: Option<Bounds>,
         #[arg(
             long,
             num_args = 1..,

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -7,6 +7,7 @@ use clap::Parser;
 mod utils;
 use chrono::NaiveDate;
 use utils::parse_date;
+pub use utils::{Bounds, CapacityPoolProvisioningMode};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]
 pub enum LoginMode {
@@ -397,7 +398,10 @@ pub enum FunctionCommand {
 
 #[derive(Debug, Parser)]
 pub enum CapacityPoolCommand {
-    #[command(about = "Create a Momento capacity pool")]
+    #[command(
+    about = "Create a Momento capacity pool",
+    group(clap::ArgGroup::new("mode").required(true)),
+    )]
     CreatePool {
         #[arg(
             long,
@@ -407,12 +411,32 @@ pub enum CapacityPoolCommand {
             value_name = "POOL"
         )]
         name: String,
-        #[arg(long, help = "EC2 instance type backing the pool's cluster")]
-        instance_type: String,
-        #[arg(long, help = "Number of shards in the backing cluster")]
-        shard_count: u32,
-        #[arg(long, help = "Replicas per shard — a single value (e.g. 2)")]
-        replicas_per_shard: u32,
+        #[arg(
+            long,
+            group = "mode",
+            requires = "shard_count",
+            help = "Explicit mode: EC2 instance type backing the pool's cluster"
+        )]
+        instance_type: Option<String>,
+        #[arg(
+            long,
+            requires = "instance_type",
+            help = "Explicit mode: number of shards in the backing cluster"
+        )]
+        shard_count: Option<u32>,
+        #[arg(
+            long,
+            help = "Replicas per shard — a single value for explicit pools (e.g. `2`), \
+                    a value or range for managed pools (e.g. `1..3`)"
+        )]
+        replicas_per_shard: Bounds,
+        #[arg(
+            long,
+            group = "mode",
+            help = "Managed mode: capacity bounds in GB — `500` pins, \
+                    `100..500` lets Momento auto-scale within the range"
+        )]
+        capacity_gb: Option<Bounds>,
         #[arg(
             long,
             required = true,
@@ -454,22 +478,38 @@ pub enum CapacityPoolCommand {
         name: String,
         #[arg(
             long,
-            help = "New EC2 instance type for the backing cluster; omit to leave unchanged",
+            value_enum,
+            help = "The pool's provisioning mode (explicit or managed)"
+        )]
+        mode: CapacityPoolProvisioningMode,
+        #[arg(
+            long,
+            help = "Explicit mode: new EC2 instance type for the backing cluster; omit to leave unchanged",
             group = "field"
         )]
         instance_type: Option<String>,
         #[arg(
             long,
-            help = "New shard count for the backing cluster; omit to leave unchanged",
+            help = "Explicit mode: new shard count for the backing cluster; omit to leave unchanged",
             group = "field"
         )]
         shard_count: Option<u32>,
         #[arg(
             long,
-            help = "New replicas per shard — a single value (e.g. 2); omit to leave unchanged",
+            help = "New replicas per shard — a single value for explicit pools (e.g. `2`), \
+                    a value or range for managed pools (e.g. `1..3`); \
+                    omit to leave unchanged",
             group = "field"
         )]
-        replicas_per_shard: Option<u32>,
+        replicas_per_shard: Option<Bounds>,
+        #[arg(
+            long,
+            help = "Managed mode: new capacity bounds in GB — `500` pins, \
+                   `100..500` lets Momento auto-scale within the range; \
+                    omit to leave unchanged",
+            group = "field"
+        )]
+        capacity_gb: Option<Bounds>,
         #[arg(
             long,
             num_args = 1..,

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -519,7 +519,7 @@ pub enum CapacityPoolCommand {
             value_name = "AVAILABILITY_ZONES",
             group = "field"
         )]
-        zones: Option<Vec<String>>,
+        zones: Vec<String>,
     },
 }
 

--- a/momento-cli-opts/src/lib.rs
+++ b/momento-cli-opts/src/lib.rs
@@ -1,12 +1,12 @@
 use std::error::Error;
 
-use clap::builder::NonEmptyStringValueParser;
 use clap::CommandFactory;
 use clap::Parser;
+use clap::{builder::NonEmptyStringValueParser, value_parser};
 
 mod utils;
 use chrono::NaiveDate;
-use utils::parse_date;
+use utils::{parse_bounds, parse_date, parse_positive_bounds};
 pub use utils::{Bounds, CapacityPoolProvisioningMode};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]
@@ -415,17 +415,20 @@ pub enum CapacityPoolCommand {
             long,
             group = "mode",
             requires = "shard_count",
+            value_parser = NonEmptyStringValueParser::new(),
             help = "Explicit mode: EC2 instance type backing the pool's cluster"
         )]
         instance_type: Option<String>,
         #[arg(
             long,
             requires = "instance_type",
+            value_parser = value_parser!(u32).range(1..),
             help = "Explicit mode: number of shards in the backing cluster"
         )]
         shard_count: Option<u32>,
         #[arg(
             long,
+            value_parser = parse_bounds,
             help = "Replicas per shard — a single value for explicit pools (e.g. `2`), \
                     a value or range for managed pools (e.g. `1..3`)"
         )]
@@ -433,6 +436,7 @@ pub enum CapacityPoolCommand {
         #[arg(
             long,
             group = "mode",
+            value_parser = parse_positive_bounds,
             help = "Managed mode: capacity bounds in GB — `500` pins, \
                     `100..500` lets Momento auto-scale within the range"
         )]
@@ -442,6 +446,7 @@ pub enum CapacityPoolCommand {
             required = true,
             num_args = 1..,
             value_delimiter = ',',
+            value_parser = NonEmptyStringValueParser::new(),
             help = "Availability zone IDs for the backing cluster, e.g. usw2-az1 (comma-delimited) — \
                     ids, not names like us-west-2a",
             value_name = "AVAILABILITY_ZONES"
@@ -484,18 +489,21 @@ pub enum CapacityPoolCommand {
         mode: CapacityPoolProvisioningMode,
         #[arg(
             long,
+            value_parser = NonEmptyStringValueParser::new(),
             help = "Explicit mode: new EC2 instance type for the backing cluster; omit to leave unchanged",
             group = "field"
         )]
         instance_type: Option<String>,
         #[arg(
             long,
+            value_parser = value_parser!(u32).range(1..),
             help = "Explicit mode: new shard count for the backing cluster; omit to leave unchanged",
             group = "field"
         )]
         shard_count: Option<u32>,
         #[arg(
             long,
+            value_parser = parse_bounds,
             help = "New replicas per shard — a single value for explicit pools (e.g. `2`), \
                     a value or range for managed pools (e.g. `1..3`); \
                     omit to leave unchanged",
@@ -504,6 +512,7 @@ pub enum CapacityPoolCommand {
         replicas_per_shard: Option<Bounds>,
         #[arg(
             long,
+            value_parser = parse_positive_bounds,
             help = "Managed mode: new capacity bounds in GB — `500` pins, \
                    `100..500` lets Momento auto-scale within the range; \
                     omit to leave unchanged",
@@ -514,6 +523,7 @@ pub enum CapacityPoolCommand {
             long,
             num_args = 1..,
             value_delimiter = ',',
+            value_parser = NonEmptyStringValueParser::new(),
             help = "Replace the zone set with these AZ IDs, e.g. usw2-az1 (comma-delimited) — \
                     ids, not names like us-west-2a; omit to leave unchanged",
             value_name = "AVAILABILITY_ZONES",

--- a/momento-cli-opts/src/utils.rs
+++ b/momento-cli-opts/src/utils.rs
@@ -6,31 +6,36 @@ pub struct Bounds {
     pub max: u32,
 }
 
-impl std::str::FromStr for Bounds {
-    type Err = String;
-
-    fn from_str(input: &str) -> Result<Bounds, String> {
-        let (min, max) = match input.split_once("..") {
-            None => (input, input),
-            Some(parts) => parts,
-        };
-        let parse = |bound: &str| {
-            bound.trim().parse::<u32>().map_err(|_| {
-                format!("`{bound}` is not a number; expected `N` (pinned) or `MIN..MAX`")
-            })
-        };
-        let bounds = Bounds {
-            min: parse(min)?,
-            max: parse(max)?,
-        };
-        if bounds.min > bounds.max {
-            return Err(format!(
-                "bounds are inverted: {}..{} (MIN must not exceed MAX)",
-                bounds.min, bounds.max
-            ));
-        }
-        Ok(bounds)
+pub fn parse_bounds(s: &str) -> Result<Bounds, String> {
+    let (min, max) = match s.split_once("..") {
+        None => (s, s),
+        Some(parts) => parts,
+    };
+    let parse = |bound: &str| {
+        bound
+            .trim()
+            .parse::<u32>()
+            .map_err(|_| format!("`{bound}` is not a number; expected `N` (pinned) or `MIN..MAX`"))
+    };
+    let bounds = Bounds {
+        min: parse(min)?,
+        max: parse(max)?,
+    };
+    if bounds.min > bounds.max {
+        return Err(format!(
+            "bounds are inverted: {}..{} (MIN must not exceed MAX)",
+            bounds.min, bounds.max
+        ));
     }
+    Ok(bounds)
+}
+
+pub fn parse_positive_bounds(s: &str) -> Result<Bounds, String> {
+    let bounds = parse_bounds(s)?;
+    if bounds.min == 0 {
+        return Err("bounds must be at least 1".to_string());
+    }
+    Ok(bounds)
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]

--- a/momento-cli-opts/src/utils.rs
+++ b/momento-cli-opts/src/utils.rs
@@ -33,7 +33,7 @@ pub fn parse_bounds(s: &str) -> Result<Bounds, String> {
 pub fn parse_positive_bounds(s: &str) -> Result<Bounds, String> {
     let bounds = parse_bounds(s)?;
     if bounds.min == 0 {
-        return Err("bounds must be at least 1".to_string());
+        return Err("bounds must be >0".to_string());
     }
     Ok(bounds)
 }

--- a/momento-cli-opts/src/utils.rs
+++ b/momento-cli-opts/src/utils.rs
@@ -1,5 +1,44 @@
 use chrono::NaiveDate;
 
+#[derive(Debug, Clone, Copy)]
+pub struct Bounds {
+    pub min: u32,
+    pub max: u32,
+}
+
+impl std::str::FromStr for Bounds {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Bounds, String> {
+        let (min, max) = match input.split_once("..") {
+            None => (input, input),
+            Some(parts) => parts,
+        };
+        let parse = |bound: &str| {
+            bound.trim().parse::<u32>().map_err(|_| {
+                format!("`{bound}` is not a number; expected `N` (pinned) or `MIN..MAX`")
+            })
+        };
+        let bounds = Bounds {
+            min: parse(min)?,
+            max: parse(max)?,
+        };
+        if bounds.min > bounds.max {
+            return Err(format!(
+                "bounds are inverted: {}..{} (MIN must not exceed MAX)",
+                bounds.min, bounds.max
+            ));
+        }
+        Ok(bounds)
+    }
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum CapacityPoolProvisioningMode {
+    Explicit,
+    Managed,
+}
+
 pub fn parse_date(s: &str) -> Result<NaiveDate, String> {
     NaiveDate::parse_from_str(s, "%Y-%m-%d")
         .map_err(|_| "Date must be in YYYY-MM-DD format".to_string())

--- a/momento/src/commands/capacity_pool/mod.rs
+++ b/momento/src/commands/capacity_pool/mod.rs
@@ -1,0 +1,2 @@
+pub mod pool_cli;
+mod utils;

--- a/momento/src/commands/capacity_pool/mod.rs
+++ b/momento/src/commands/capacity_pool/mod.rs
@@ -1,2 +1,2 @@
 pub mod pool_cli;
-mod utils;
+pub mod utils;

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -1,6 +1,5 @@
-use super::utils::{
-    call_pool_http_api, ExplicitProvisioning, ExplicitProvisioningUpdate, Response,
-};
+use super::utils::{call_pool_api, ExplicitProvisioning, ExplicitProvisioningUpdate};
+use crate::commands::utils::MomentoHttpResponse::{Parsed, Unparseable};
 use crate::{error::CliError, utils::console::console_data};
 
 use http::Method;
@@ -25,8 +24,8 @@ pub async fn create_pool(
             }
         }
     });
-    match call_pool_http_api(Method::POST, endpoint, auth_token, name, Some(data)).await? {
-        Response::Parsed(pool) => {
+    match call_pool_api(Method::POST, endpoint, auth_token, name, Some(data)).await? {
+        Parsed(pool) => {
             console_data!(
                 "Creating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
@@ -34,7 +33,7 @@ pub async fn create_pool(
                 serde_json::to_string_pretty(&pool.provisioning.explicit)?,
             );
         }
-        Response::Unparseable(response_text) => {
+        Unparseable(response_text) => {
             console_data!("Creating pool! {response_text}");
         }
     };
@@ -46,11 +45,11 @@ pub async fn get_status(
     auth_token: String,
     name: String,
 ) -> Result<(), CliError> {
-    match call_pool_http_api(Method::GET, endpoint, auth_token, name, None).await? {
-        Response::Parsed(pool) => {
+    match call_pool_api(Method::GET, endpoint, auth_token, name, None).await? {
+        Parsed(pool) => {
             console_data!("Pool status for {}: {}", pool.name, pool.status);
         }
-        Response::Unparseable(response_text) => {
+        Unparseable(response_text) => {
             console_data!("{response_text}");
         }
     };
@@ -76,8 +75,8 @@ pub async fn update_pool(
             }
         }
     });
-    match call_pool_http_api(Method::PATCH, endpoint, auth_token, name, Some(data)).await? {
-        Response::Parsed(pool) => {
+    match call_pool_api(Method::PATCH, endpoint, auth_token, name, Some(data)).await? {
+        Parsed(pool) => {
             console_data!(
                 "Updating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
@@ -85,7 +84,7 @@ pub async fn update_pool(
                 serde_json::to_string_pretty(&pool.provisioning.explicit)?,
             );
         }
-        Response::Unparseable(response_text) => {
+        Unparseable(response_text) => {
             console_data!("Updating pool! {response_text}");
         }
     };

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -1,9 +1,9 @@
-use super::utils::{ExplicitProvisioning, ExplicitProvisioningUpdate, PoolError, PoolResponse};
+use super::utils::{
+    call_pool_http_api, ExplicitProvisioning, ExplicitProvisioningUpdate, Response,
+};
 use crate::{error::CliError, utils::console::console_data};
 
 use http::Method;
-use log::{info, warn};
-use reqwest;
 use serde_json;
 
 pub async fn create_pool(
@@ -15,7 +15,6 @@ pub async fn create_pool(
     replicas_per_shard: u32,
     zones: Vec<String>,
 ) -> Result<(), CliError> {
-    let request_url = format!("{endpoint}/capacity_pool/{name}");
     let data = serde_json::json!({
         "provisioning": {
             "explicit": ExplicitProvisioning {
@@ -25,51 +24,21 @@ pub async fn create_pool(
                 zones,
             }
         }
-    })
-    .to_string();
-
-    let req_client = reqwest::Client::builder().build()?;
-    let response = req_client
-        .request(Method::POST, &request_url)
-        .body(data)
-        .header("authorization", &auth_token)
-        .header("content-type", "application/json")
-        .send()
-        .await?;
-    let status = response.status();
-    if status.is_success() {
-        let response_text = response.text().await?;
-        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
-            Ok(pool) => {
-                info!("Response sent back by {name} pool creation:\n{pool:#?}");
-                console_data!(
-                    "Creating pool! Name: {}, Status: {}, Provisioning: {:#?}",
-                    pool.name,
-                    pool.status,
-                    pool.provisioning.explicit,
-                );
-            }
-            Err(err) => {
-                warn!("Can't parse response from {name} pool creation:\n{response_text}\n{err}");
-                console_data!("Creating pool! {response_text}");
-            }
-        };
-        Ok(())
-    } else {
-        let error_text = response.text().await?;
-        Err(CliError::new(if error_text.is_empty() {
-            format!("{status}")
-        } else {
-            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
-                Ok(error) => error
-                    .detail
-                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
-                Err(_) => error_text.clone(),
-            };
-            format!("{status}: {error_message}")
-        })
-        .with_details(error_text))
-    }
+    });
+    match call_pool_http_api(Method::POST, endpoint, auth_token, name, Some(data)).await? {
+        Response::Parsed(pool) => {
+            console_data!(
+                "Creating pool! Name: {}, Status: {}, Provisioning: {:#?}",
+                pool.name,
+                pool.status,
+                pool.provisioning.explicit,
+            );
+        }
+        Response::Unparseable(response_text) => {
+            console_data!("Creating pool! {response_text}");
+        }
+    };
+    Ok(())
 }
 
 pub async fn get_status(
@@ -77,43 +46,15 @@ pub async fn get_status(
     auth_token: String,
     name: String,
 ) -> Result<(), CliError> {
-    let request_url = format!("{endpoint}/capacity_pool/{name}");
-
-    let req_client = reqwest::Client::builder().build()?;
-    let response = req_client
-        .request(Method::GET, &request_url)
-        .header("authorization", &auth_token)
-        .send()
-        .await?;
-    let status = response.status();
-    if status.is_success() {
-        let response_text = response.text().await?;
-        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
-            Ok(pool) => {
-                info!("Response sent back by {name} pool describe:\n{pool:#?}");
-                console_data!("Pool status for {}: {}", pool.name, pool.status);
-            }
-            Err(err) => {
-                warn!("Can't parse response from {name} pool describe:\n{response_text}\n{err}");
-                console_data!("{response_text}");
-            }
-        };
-        Ok(())
-    } else {
-        let error_text = response.text().await?;
-        Err(CliError::new(if error_text.is_empty() {
-            format!("{status}")
-        } else {
-            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
-                Ok(error) => error
-                    .detail
-                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
-                Err(_) => error_text.clone(),
-            };
-            format!("{status}: {error_message}")
-        })
-        .with_details(error_text))
-    }
+    match call_pool_http_api(Method::GET, endpoint, auth_token, name, None).await? {
+        Response::Parsed(pool) => {
+            console_data!("Pool status for {}: {}", pool.name, pool.status);
+        }
+        Response::Unparseable(response_text) => {
+            console_data!("{response_text}");
+        }
+    };
+    Ok(())
 }
 
 pub async fn update_pool(
@@ -125,7 +66,6 @@ pub async fn update_pool(
     replicas_per_shard: Option<u32>,
     zones: Option<Vec<String>>,
 ) -> Result<(), CliError> {
-    let request_url = format!("{endpoint}/capacity_pool/{name}");
     let data = serde_json::json!({
         "provisioning": {
             "explicit": ExplicitProvisioningUpdate {
@@ -135,49 +75,19 @@ pub async fn update_pool(
                 zones,
             }
         }
-    })
-    .to_string();
-
-    let req_client = reqwest::Client::builder().build()?;
-    let response = req_client
-        .request(Method::PATCH, &request_url)
-        .body(data)
-        .header("authorization", &auth_token)
-        .header("content-type", "application/json")
-        .send()
-        .await?;
-    let status = response.status();
-    if status.is_success() {
-        let response_text = response.text().await?;
-        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
-            Ok(pool) => {
-                info!("Response sent back by {name} pool update:\n{pool:#?}");
-                console_data!(
-                    "Updating pool! Name: {}, Status: {}, Provisioning: {:#?}",
-                    pool.name,
-                    pool.status,
-                    pool.provisioning.explicit,
-                );
-            }
-            Err(err) => {
-                warn!("Can't parse response from {name} pool update:\n{response_text}\n{err}");
-                console_data!("Updating pool! {response_text}");
-            }
-        };
-        Ok(())
-    } else {
-        let error_text = response.text().await?;
-        Err(CliError::new(if error_text.is_empty() {
-            format!("{status}")
-        } else {
-            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
-                Ok(error) => error
-                    .detail
-                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
-                Err(_) => error_text.clone(),
-            };
-            format!("{status}: {error_message}")
-        })
-        .with_details(error_text))
-    }
+    });
+    match call_pool_http_api(Method::PATCH, endpoint, auth_token, name, Some(data)).await? {
+        Response::Parsed(pool) => {
+            console_data!(
+                "Updating pool! Name: {}, Status: {}, Provisioning: {:#?}",
+                pool.name,
+                pool.status,
+                pool.provisioning.explicit,
+            );
+        }
+        Response::Unparseable(response_text) => {
+            console_data!("Updating pool! {response_text}");
+        }
+    };
+    Ok(())
 }

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -28,10 +28,10 @@ pub async fn create_pool(
     match call_pool_http_api(Method::POST, endpoint, auth_token, name, Some(data)).await? {
         Response::Parsed(pool) => {
             console_data!(
-                "Creating pool! Name: {}, Status: {}, Provisioning: {:#?}",
+                "Creating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
-                pool.provisioning.explicit,
+                serde_json::to_string_pretty(&pool.provisioning.explicit)?,
             );
         }
         Response::Unparseable(response_text) => {
@@ -79,10 +79,10 @@ pub async fn update_pool(
     match call_pool_http_api(Method::PATCH, endpoint, auth_token, name, Some(data)).await? {
         Response::Parsed(pool) => {
             console_data!(
-                "Updating pool! Name: {}, Status: {}, Provisioning: {:#?}",
+                "Updating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
-                pool.provisioning.explicit,
+                serde_json::to_string_pretty(&pool.provisioning.explicit)?,
             );
         }
         Response::Unparseable(response_text) => {

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -22,7 +22,7 @@ pub async fn create_pool(
                 "Creating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
-                serde_json::to_string_pretty(&pool.provisioning)?,
+                pool.provisioning,
             );
         }
         Unparseable(response_text) => {
@@ -61,7 +61,7 @@ pub async fn update_pool(
                 "Updating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
-                serde_json::to_string_pretty(&pool.provisioning)?,
+                pool.provisioning,
             );
         }
         Unparseable(response_text) => {
@@ -96,8 +96,9 @@ pub async fn list_pools(endpoint: String, auth_token: String) -> Result<(), CliE
                         "\nName: {}, Status: {}, Provisioning: {}, Diagnostics: {}",
                         pool.name,
                         pool.status,
-                        serde_json::to_string_pretty(&pool.provisioning)?,
-                        serde_json::to_string_pretty(&pool.diagnostics)?,
+                        pool.provisioning,
+                        serde_json::to_string_pretty(&pool.diagnostics)
+                            .unwrap_or_else(|_| format!("{:#?}", pool.diagnostics)),
                     );
                 }
             }

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -1,4 +1,8 @@
-use super::utils::{call_pool_api, CapacityPoolProvisioning, CapacityPoolProvisioningUpdate};
+use super::utils::{
+    call_pool_api, call_pool_delete_api, call_pool_list_api, CapacityPoolProvisioning,
+    CapacityPoolProvisioningUpdate,
+};
+use crate::commands::capacity_pool::utils::ListCapacityPoolsResponse;
 use crate::commands::utils::MomentoHttpResponse::{Parsed, Unparseable};
 use crate::{error::CliError, utils::console::console_data};
 
@@ -62,6 +66,44 @@ pub async fn update_pool(
         }
         Unparseable(response_text) => {
             console_data!("Updating pool! {response_text}");
+        }
+    };
+    Ok(())
+}
+
+pub async fn delete_pool(
+    endpoint: String,
+    auth_token: String,
+    name: String,
+) -> Result<(), CliError> {
+    let response_text = call_pool_delete_api(endpoint, auth_token, name).await?;
+    console_data!("Deleting pool! {response_text}");
+    Ok(())
+}
+
+pub async fn list_pools(endpoint: String, auth_token: String) -> Result<(), CliError> {
+    let response = call_pool_list_api(endpoint, auth_token).await?;
+    match response {
+        Parsed(ListCapacityPoolsResponse {
+            capacity_pools: pools_list,
+        }) => {
+            if pools_list.is_empty() {
+                console_data!("No capacity pools found");
+            } else {
+                console_data!("Capacity pools:");
+                for pool in pools_list.iter() {
+                    console_data!(
+                        "\nName: {}, Status: {}, Provisioning: {}, Diagnostics: {}",
+                        pool.name,
+                        pool.status,
+                        serde_json::to_string_pretty(&pool.provisioning)?,
+                        serde_json::to_string_pretty(&pool.diagnostics)?,
+                    );
+                }
+            }
+        }
+        Unparseable(response_text) => {
+            console_data!("Listing capacity pools:\n{response_text}");
         }
     };
     Ok(())

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -1,0 +1,183 @@
+use super::utils::{ExplicitProvisioning, ExplicitProvisioningUpdate, PoolError, PoolResponse};
+use crate::{error::CliError, utils::console::console_data};
+
+use http::Method;
+use log::{info, warn};
+use reqwest;
+use serde_json;
+
+pub async fn create_pool(
+    endpoint: String,
+    auth_token: String,
+    name: String,
+    instance_type: String,
+    shard_count: u32,
+    replicas_per_shard: u32,
+    zones: Vec<String>,
+) -> Result<(), CliError> {
+    let request_url = format!("{endpoint}/capacity_pool/{name}");
+    let data = serde_json::json!({
+        "provisioning": {
+            "explicit": ExplicitProvisioning {
+                instance_type,
+                shard_count,
+                replicas_per_shard,
+                zones,
+            }
+        }
+    })
+    .to_string();
+
+    let req_client = reqwest::Client::builder().build()?;
+    let response = req_client
+        .request(Method::POST, &request_url)
+        .body(data)
+        .header("authorization", &auth_token)
+        .header("content-type", "application/json")
+        .send()
+        .await?;
+    let status = response.status();
+    if status.is_success() {
+        let response_text = response.text().await?;
+        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
+            Ok(pool) => {
+                info!("Response sent back by {name} pool creation:\n{pool:#?}");
+                console_data!(
+                    "Creating pool! Name: {}, Status: {}, Provisioning: {:#?}",
+                    pool.name,
+                    pool.status,
+                    pool.provisioning.explicit,
+                );
+            }
+            Err(err) => {
+                warn!("Can't parse response from {name} pool creation:\n{response_text}\n{err}");
+                console_data!("Creating pool! {response_text}");
+            }
+        };
+        Ok(())
+    } else {
+        let error_text = response.text().await?;
+        Err(CliError::new(if error_text.is_empty() {
+            format!("{status}")
+        } else {
+            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
+                Ok(error) => error
+                    .detail
+                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
+                Err(_) => error_text.clone(),
+            };
+            format!("{status}: {error_message}")
+        })
+        .with_details(error_text))
+    }
+}
+
+pub async fn get_status(
+    endpoint: String,
+    auth_token: String,
+    name: String,
+) -> Result<(), CliError> {
+    let request_url = format!("{endpoint}/capacity_pool/{name}");
+
+    let req_client = reqwest::Client::builder().build()?;
+    let response = req_client
+        .request(Method::GET, &request_url)
+        .header("authorization", &auth_token)
+        .send()
+        .await?;
+    let status = response.status();
+    if status.is_success() {
+        let response_text = response.text().await?;
+        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
+            Ok(pool) => {
+                info!("Response sent back by {name} pool describe:\n{pool:#?}");
+                console_data!("Pool status for {}: {}", pool.name, pool.status);
+            }
+            Err(err) => {
+                warn!("Can't parse response from {name} pool describe:\n{response_text}\n{err}");
+                console_data!("{response_text}");
+            }
+        };
+        Ok(())
+    } else {
+        let error_text = response.text().await?;
+        Err(CliError::new(if error_text.is_empty() {
+            format!("{status}")
+        } else {
+            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
+                Ok(error) => error
+                    .detail
+                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
+                Err(_) => error_text.clone(),
+            };
+            format!("{status}: {error_message}")
+        })
+        .with_details(error_text))
+    }
+}
+
+pub async fn update_pool(
+    endpoint: String,
+    auth_token: String,
+    name: String,
+    instance_type: Option<String>,
+    shard_count: Option<u32>,
+    replicas_per_shard: Option<u32>,
+    zones: Option<Vec<String>>,
+) -> Result<(), CliError> {
+    let request_url = format!("{endpoint}/capacity_pool/{name}");
+    let data = serde_json::json!({
+        "provisioning": {
+            "explicit": ExplicitProvisioningUpdate {
+                instance_type,
+                shard_count,
+                replicas_per_shard,
+                zones,
+            }
+        }
+    })
+    .to_string();
+
+    let req_client = reqwest::Client::builder().build()?;
+    let response = req_client
+        .request(Method::PATCH, &request_url)
+        .body(data)
+        .header("authorization", &auth_token)
+        .header("content-type", "application/json")
+        .send()
+        .await?;
+    let status = response.status();
+    if status.is_success() {
+        let response_text = response.text().await?;
+        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
+            Ok(pool) => {
+                info!("Response sent back by {name} pool update:\n{pool:#?}");
+                console_data!(
+                    "Updating pool! Name: {}, Status: {}, Provisioning: {:#?}",
+                    pool.name,
+                    pool.status,
+                    pool.provisioning.explicit,
+                );
+            }
+            Err(err) => {
+                warn!("Can't parse response from {name} pool update:\n{response_text}\n{err}");
+                console_data!("Updating pool! {response_text}");
+            }
+        };
+        Ok(())
+    } else {
+        let error_text = response.text().await?;
+        Err(CliError::new(if error_text.is_empty() {
+            format!("{status}")
+        } else {
+            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
+                Ok(error) => error
+                    .detail
+                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
+                Err(_) => error_text.clone(),
+            };
+            format!("{status}: {error_message}")
+        })
+        .with_details(error_text))
+    }
+}

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -19,14 +19,14 @@ pub async fn create_pool(
     match call_pool_api(Method::POST, endpoint, auth_token, name, Some(data)).await? {
         Parsed(pool) => {
             console_data!(
-                "Creating pool! Name: {}, Status: {}, Provisioning: {}",
+                "Creating capacity pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
                 pool.provisioning,
             );
         }
         Unparseable(response_text) => {
-            console_data!("Creating pool! {response_text}");
+            console_data!("Creating capacity pool! {response_text}");
         }
     };
     Ok(())
@@ -39,7 +39,7 @@ pub async fn get_status(
 ) -> Result<(), CliError> {
     match call_pool_api(Method::GET, endpoint, auth_token, name, None).await? {
         Parsed(pool) => {
-            console_data!("Pool status for {}: {}", pool.name, pool.status);
+            console_data!("Capacity pool status for {}: {}", pool.name, pool.status);
         }
         Unparseable(response_text) => {
             console_data!("{response_text}");
@@ -58,14 +58,14 @@ pub async fn update_pool(
     match call_pool_api(Method::PATCH, endpoint, auth_token, name, Some(data)).await? {
         Parsed(pool) => {
             console_data!(
-                "Updating pool! Name: {}, Status: {}, Provisioning: {}",
+                "Updating capacity pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
                 pool.provisioning,
             );
         }
         Unparseable(response_text) => {
-            console_data!("Updating pool! {response_text}");
+            console_data!("Updating capacity pool! {response_text}");
         }
     };
     Ok(())
@@ -76,8 +76,8 @@ pub async fn delete_pool(
     auth_token: String,
     name: String,
 ) -> Result<(), CliError> {
-    let response_text = call_pool_delete_api(endpoint, auth_token, name).await?;
-    console_data!("Deleting pool! {response_text}");
+    let response_text = call_pool_delete_api(endpoint, auth_token, name.clone()).await?;
+    console_data!("Deleting capacity pool {name}! {response_text}");
     Ok(())
 }
 

--- a/momento/src/commands/capacity_pool/pool_cli.rs
+++ b/momento/src/commands/capacity_pool/pool_cli.rs
@@ -1,4 +1,4 @@
-use super::utils::{call_pool_api, ExplicitProvisioning, ExplicitProvisioningUpdate};
+use super::utils::{call_pool_api, CapacityPoolProvisioning, CapacityPoolProvisioningUpdate};
 use crate::commands::utils::MomentoHttpResponse::{Parsed, Unparseable};
 use crate::{error::CliError, utils::console::console_data};
 
@@ -9,28 +9,16 @@ pub async fn create_pool(
     endpoint: String,
     auth_token: String,
     name: String,
-    instance_type: String,
-    shard_count: u32,
-    replicas_per_shard: u32,
-    zones: Vec<String>,
+    provisioning: CapacityPoolProvisioning,
 ) -> Result<(), CliError> {
-    let data = serde_json::json!({
-        "provisioning": {
-            "explicit": ExplicitProvisioning {
-                instance_type,
-                shard_count,
-                replicas_per_shard,
-                zones,
-            }
-        }
-    });
+    let data = serde_json::json!({"provisioning": provisioning});
     match call_pool_api(Method::POST, endpoint, auth_token, name, Some(data)).await? {
         Parsed(pool) => {
             console_data!(
                 "Creating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
-                serde_json::to_string_pretty(&pool.provisioning.explicit)?,
+                serde_json::to_string_pretty(&pool.provisioning)?,
             );
         }
         Unparseable(response_text) => {
@@ -60,28 +48,16 @@ pub async fn update_pool(
     endpoint: String,
     auth_token: String,
     name: String,
-    instance_type: Option<String>,
-    shard_count: Option<u32>,
-    replicas_per_shard: Option<u32>,
-    zones: Option<Vec<String>>,
+    provisioning_update: CapacityPoolProvisioningUpdate,
 ) -> Result<(), CliError> {
-    let data = serde_json::json!({
-        "provisioning": {
-            "explicit": ExplicitProvisioningUpdate {
-                instance_type,
-                shard_count,
-                replicas_per_shard,
-                zones,
-            }
-        }
-    });
+    let data = serde_json::json!({"provisioning": provisioning_update});
     match call_pool_api(Method::PATCH, endpoint, auth_token, name, Some(data)).await? {
         Parsed(pool) => {
             console_data!(
                 "Updating pool! Name: {}, Status: {}, Provisioning: {}",
                 pool.name,
                 pool.status,
-                serde_json::to_string_pretty(&pool.provisioning.explicit)?,
+                serde_json::to_string_pretty(&pool.provisioning)?,
             );
         }
         Unparseable(response_text) => {

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -61,16 +61,16 @@ pub enum CapacityPoolProvisioningUpdate {
         shard_count: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         replicas_per_shard: Option<u32>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        zones: Option<Vec<String>>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        zones: Vec<String>,
     },
     Managed {
         #[serde(skip_serializing_if = "Option::is_none")]
         capacity: Option<CapacityBounds>,
         #[serde(skip_serializing_if = "Option::is_none")]
         replication: Option<ReplicationBounds>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        zones: Option<Vec<String>>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        zones: Vec<String>,
     },
 }
 
@@ -131,7 +131,7 @@ pub fn determine_provisioning_update(
     shard_count: Option<u32>,
     replicas_per_shard: Option<Bounds>,
     capacity_gb: Option<Bounds>,
-    zones: Option<Vec<String>>,
+    zones: Vec<String>,
 ) -> Result<CapacityPoolProvisioningUpdate, CliError> {
     let update = match mode {
         CapacityPoolProvisioningMode::Explicit => {

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -1,10 +1,8 @@
-use crate::error::CliError;
+use crate::commands::utils::{call_momento_http_api, MomentoHttpData, MomentoHttpResponse};
 
+use crate::error::CliError;
 use http::Method;
-use log::{info, warn};
-use reqwest;
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ExplicitProvisioning {
@@ -38,64 +36,19 @@ pub struct PoolResponse {
     pub provisioning: Provisioning,
 }
 
-#[derive(Deserialize)]
-struct PoolError {
-    pub detail: Option<String>,
-    pub message: Option<String>,
-}
-
-pub enum Response {
-    Parsed(PoolResponse),
-    Unparseable(String),
-}
-
-pub async fn call_pool_http_api(
+pub async fn call_pool_api(
     method: Method,
     endpoint: String,
     auth_token: String,
-    name: String,
+    pool_name: String,
     data: Option<serde_json::Value>,
-) -> Result<Response, CliError> {
-    let request_url = format!("{endpoint}/capacity_pool/{name}");
-
-    let req_client = reqwest::Client::builder().build()?;
-    let response = req_client
-        .request(method.clone(), &request_url)
-        .header("authorization", &auth_token)
-        .header("content-type", "application/json")
-        .body(data.unwrap_or_default().to_string())
-        .send()
-        .await?;
-    let status = response.status();
-
-    if status.is_success() {
-        let response_text = response.text().await?;
-        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
-            Ok(response) => {
-                info!("Response sent back from {method} /capacity_pool/{name}:\n{response:#?}");
-                Ok(Response::Parsed(response))
-            }
-            Err(err) => {
-                warn!(
-                    "Can't parse response from {method} /capacity_pool/{name}: \
-                    \n{response_text}\n{err}"
-                );
-                Ok(Response::Unparseable(response_text))
-            }
-        }
-    } else {
-        let error_text = response.text().await?;
-        Err(CliError::new(if error_text.is_empty() {
-            format!("{status}")
-        } else {
-            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
-                Ok(error) => error
-                    .detail
-                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
-                Err(_) => error_text.clone(),
-            };
-            format!("{status}: {error_message}")
-        })
-        .with_details(error_text))
-    }
+) -> Result<MomentoHttpResponse<PoolResponse>, CliError> {
+    call_momento_http_api(
+        method,
+        format!("{endpoint}/capacity_pool/{pool_name}"),
+        auth_token,
+        None,
+        data.map(MomentoHttpData::Json),
+    )
+    .await
 }

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -1,4 +1,6 @@
-use crate::commands::utils::{call_momento_http_api, MomentoHttpData, MomentoHttpResponse};
+use crate::commands::utils::{
+    call_momento_http_api, call_momento_http_api_raw, MomentoHttpData, MomentoHttpResponse,
+};
 use crate::error::CliError;
 use momento_cli_opts::{Bounds, CapacityPoolProvisioningMode};
 
@@ -79,6 +81,13 @@ pub struct CapacityPoolResponse {
     pub name: String,
     pub status: String,
     pub provisioning: CapacityPoolProvisioning,
+    #[serde(default)]
+    pub diagnostics: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListCapacityPoolsResponse {
+    pub capacity_pools: Vec<CapacityPoolResponse>,
 }
 
 /// The single, pinned `--replicas-per-shard` that's required by explicit provisioning.
@@ -165,6 +174,13 @@ pub fn determine_provisioning_update(
     Ok(update)
 }
 
+fn build_request_url(endpoint: String, pool_name: Option<String>) -> String {
+    match pool_name {
+        None => format!("{endpoint}/capacity_pool"),
+        Some(name) => format!("{endpoint}/capacity_pool/{name}"),
+    }
+}
+
 pub async fn call_pool_api(
     method: Method,
     endpoint: String,
@@ -174,10 +190,39 @@ pub async fn call_pool_api(
 ) -> Result<MomentoHttpResponse<CapacityPoolResponse>, CliError> {
     call_momento_http_api(
         method,
-        format!("{endpoint}/capacity_pool/{pool_name}"),
+        build_request_url(endpoint, Some(pool_name)),
         auth_token,
         None,
         data.map(MomentoHttpData::Json),
+    )
+    .await
+}
+
+pub async fn call_pool_delete_api(
+    endpoint: String,
+    auth_token: String,
+    pool_name: String,
+) -> Result<String, CliError> {
+    call_momento_http_api_raw(
+        Method::DELETE,
+        build_request_url(endpoint, Some(pool_name)),
+        auth_token,
+        None,
+        None,
+    )
+    .await
+}
+
+pub async fn call_pool_list_api(
+    endpoint: String,
+    auth_token: String,
+) -> Result<MomentoHttpResponse<ListCapacityPoolsResponse>, CliError> {
+    call_momento_http_api(
+        Method::GET,
+        build_request_url(endpoint, None),
+        auth_token,
+        None,
+        None,
     )
     .await
 }

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -1,39 +1,168 @@
 use crate::commands::utils::{call_momento_http_api, MomentoHttpData, MomentoHttpResponse};
-
 use crate::error::CliError;
+use momento_cli_opts::{Bounds, CapacityPoolProvisioningMode};
+
 use http::Method;
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
-pub struct ExplicitProvisioning {
-    pub instance_type: String,
-    pub shard_count: u32,
-    pub replicas_per_shard: u32,
-    pub zones: Vec<String>,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CapacityBounds {
+    pub min_gb: u32,
+    pub max_gb: u32,
 }
 
-#[derive(Serialize)]
-pub struct ExplicitProvisioningUpdate {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub instance_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub shard_count: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub replicas_per_shard: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub zones: Option<Vec<String>>,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ReplicationBounds {
+    pub min_replicas_per_shard: u32,
+    pub max_replicas_per_shard: u32,
+}
+
+impl From<Bounds> for CapacityBounds {
+    fn from(bounds: Bounds) -> Self {
+        Self {
+            min_gb: bounds.min,
+            max_gb: bounds.max,
+        }
+    }
+}
+
+impl From<Bounds> for ReplicationBounds {
+    fn from(bounds: Bounds) -> Self {
+        Self {
+            min_replicas_per_shard: bounds.min,
+            max_replicas_per_shard: bounds.max,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacityPoolProvisioning {
+    Explicit {
+        instance_type: String,
+        shard_count: u32,
+        replicas_per_shard: u32,
+        zones: Vec<String>,
+    },
+    Managed {
+        capacity: CapacityBounds,
+        replication: ReplicationBounds,
+        zones: Vec<String>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacityPoolProvisioningUpdate {
+    Explicit {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        instance_type: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        shard_count: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        replicas_per_shard: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        zones: Option<Vec<String>>,
+    },
+    Managed {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        capacity: Option<CapacityBounds>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        replication: Option<ReplicationBounds>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        zones: Option<Vec<String>>,
+    },
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Provisioning {
-    pub explicit: ExplicitProvisioning,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct PoolResponse {
+pub struct CapacityPoolResponse {
     pub name: String,
     pub status: String,
-    pub provisioning: Provisioning,
+    pub provisioning: CapacityPoolProvisioning,
+}
+
+/// The single, pinned `--replicas-per-shard` that's required by explicit provisioning.
+fn pinned(bounds: Bounds) -> Result<u32, CliError> {
+    (bounds.min == bounds.max)
+        .then_some(bounds.min)
+        .ok_or_else(|| {
+            CliError::new(
+                "explicit pools take a single --replicas-per-shard (e.g. 2); \
+                 ranges are for managed pools",
+            )
+        })
+}
+
+pub fn determine_provisioning(
+    instance_type: Option<String>,
+    shard_count: Option<u32>,
+    replicas_per_shard: Bounds,
+    capacity_gb: Option<Bounds>,
+    zones: Vec<String>,
+) -> Result<CapacityPoolProvisioning, CliError> {
+    let provisioning = match (instance_type, shard_count, capacity_gb) {
+        (Some(instance_type), Some(shard_count), None) => {
+            let replicas_per_shard = pinned(replicas_per_shard)?;
+            CapacityPoolProvisioning::Explicit {
+                instance_type,
+                shard_count,
+                replicas_per_shard,
+                zones,
+            }
+        }
+        (None, None, Some(capacity)) => CapacityPoolProvisioning::Managed {
+            capacity: CapacityBounds::from(capacity),
+            replication: ReplicationBounds::from(replicas_per_shard),
+            zones,
+        },
+        _ => {
+            return Err(CliError::new(
+                "pass either --instance-type with --shard-count (explicit) \
+                 or --capacity-gb (managed)",
+            ));
+        }
+    };
+    Ok(provisioning)
+}
+
+pub fn determine_provisioning_update(
+    mode: CapacityPoolProvisioningMode,
+    instance_type: Option<String>,
+    shard_count: Option<u32>,
+    replicas_per_shard: Option<Bounds>,
+    capacity_gb: Option<Bounds>,
+    zones: Option<Vec<String>>,
+) -> Result<CapacityPoolProvisioningUpdate, CliError> {
+    let update = match mode {
+        CapacityPoolProvisioningMode::Explicit => {
+            if capacity_gb.is_some() {
+                return Err(CliError::new(
+                    "--capacity-gb is a managed-mode field; pass --mode managed",
+                ));
+            }
+            let replicas_per_shard = replicas_per_shard.map(pinned).transpose()?;
+            CapacityPoolProvisioningUpdate::Explicit {
+                instance_type,
+                shard_count,
+                replicas_per_shard,
+                zones,
+            }
+        }
+        CapacityPoolProvisioningMode::Managed => {
+            if instance_type.is_some() || shard_count.is_some() {
+                return Err(CliError::new(
+                    "--instance-type and --shard-count are explicit-mode fields; \
+                     pass --mode explicit",
+                ));
+            }
+            CapacityPoolProvisioningUpdate::Managed {
+                capacity: capacity_gb.map(CapacityBounds::from),
+                replication: replicas_per_shard.map(ReplicationBounds::from),
+                zones,
+            }
+        }
+    };
+    Ok(update)
 }
 
 pub async fn call_pool_api(
@@ -42,7 +171,7 @@ pub async fn call_pool_api(
     auth_token: String,
     pool_name: String,
     data: Option<serde_json::Value>,
-) -> Result<MomentoHttpResponse<PoolResponse>, CliError> {
+) -> Result<MomentoHttpResponse<CapacityPoolResponse>, CliError> {
     call_momento_http_api(
         method,
         format!("{endpoint}/capacity_pool/{pool_name}"),

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ExplicitProvisioning {
+    pub instance_type: String,
+    pub shard_count: u32,
+    pub replicas_per_shard: u32,
+    pub zones: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct ExplicitProvisioningUpdate {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub shard_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replicas_per_shard: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zones: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Provisioning {
+    pub explicit: ExplicitProvisioning,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PoolResponse {
+    pub name: String,
+    pub status: String,
+    pub provisioning: Provisioning,
+}
+
+#[derive(Deserialize)]
+pub struct PoolError {
+    pub detail: Option<String>,
+    pub message: Option<String>,
+}

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -1,4 +1,10 @@
+use crate::error::CliError;
+
+use http::Method;
+use log::{info, warn};
+use reqwest;
 use serde::{Deserialize, Serialize};
+use serde_json;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct ExplicitProvisioning {
@@ -33,7 +39,63 @@ pub struct PoolResponse {
 }
 
 #[derive(Deserialize)]
-pub struct PoolError {
+struct PoolError {
     pub detail: Option<String>,
     pub message: Option<String>,
+}
+
+pub enum Response {
+    Parsed(PoolResponse),
+    Unparseable(String),
+}
+
+pub async fn call_pool_http_api(
+    method: Method,
+    endpoint: String,
+    auth_token: String,
+    name: String,
+    data: Option<serde_json::Value>,
+) -> Result<Response, CliError> {
+    let request_url = format!("{endpoint}/capacity_pool/{name}");
+
+    let req_client = reqwest::Client::builder().build()?;
+    let response = req_client
+        .request(method.clone(), &request_url)
+        .header("authorization", &auth_token)
+        .header("content-type", "application/json")
+        .body(data.unwrap_or_default().to_string())
+        .send()
+        .await?;
+    let status = response.status();
+
+    if status.is_success() {
+        let response_text = response.text().await?;
+        match serde_json::from_str::<PoolResponse>(response_text.as_str()) {
+            Ok(response) => {
+                info!("Response sent back from {method} /capacity_pool/{name}:\n{response:#?}");
+                Ok(Response::Parsed(response))
+            }
+            Err(err) => {
+                warn!(
+                    "Can't parse response from {method} /capacity_pool/{name}: \
+                    \n{response_text}\n{err}"
+                );
+                Ok(Response::Unparseable(response_text))
+            }
+        }
+    } else {
+        let error_text = response.text().await?;
+        Err(CliError::new(if error_text.is_empty() {
+            format!("{status}")
+        } else {
+            let error_message = match serde_json::from_str::<PoolError>(error_text.as_str()) {
+                Ok(error) => error
+                    .detail
+                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
+                Err(_) => error_text.clone(),
+            };
+            format!("{status}: {error_message}")
+        })
+        .with_details(error_text))
+    }
 }

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -6,6 +6,7 @@ use momento_cli_opts::{Bounds, CapacityPoolProvisioningMode};
 
 use http::Method;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CapacityBounds {
@@ -51,6 +52,15 @@ pub enum CapacityPoolProvisioning {
         replication: ReplicationBounds,
         zones: Vec<String>,
     },
+}
+
+impl fmt::Display for CapacityPoolProvisioning {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match serde_json::to_string_pretty(self) {
+            Ok(pretty) => write!(f, "{pretty}"),
+            Err(_) => write!(f, "{self:?}"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/momento/src/commands/capacity_pool/utils.rs
+++ b/momento/src/commands/capacity_pool/utils.rs
@@ -10,8 +10,8 @@ use std::fmt;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CapacityBounds {
-    pub min_gb: u32,
-    pub max_gb: u32,
+    pub min_gib: u32,
+    pub max_gib: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -23,8 +23,8 @@ pub struct ReplicationBounds {
 impl From<Bounds> for CapacityBounds {
     fn from(bounds: Bounds) -> Self {
         Self {
-            min_gb: bounds.min,
-            max_gb: bounds.max,
+            min_gib: bounds.min,
+            max_gib: bounds.max,
         }
     }
 }
@@ -116,10 +116,10 @@ pub fn determine_provisioning(
     instance_type: Option<String>,
     shard_count: Option<u32>,
     replicas_per_shard: Bounds,
-    capacity_gb: Option<Bounds>,
+    capacity_gib: Option<Bounds>,
     zones: Vec<String>,
 ) -> Result<CapacityPoolProvisioning, CliError> {
-    let provisioning = match (instance_type, shard_count, capacity_gb) {
+    let provisioning = match (instance_type, shard_count, capacity_gib) {
         (Some(instance_type), Some(shard_count), None) => {
             let replicas_per_shard = pinned(replicas_per_shard)?;
             CapacityPoolProvisioning::Explicit {
@@ -137,7 +137,7 @@ pub fn determine_provisioning(
         _ => {
             return Err(CliError::new(
                 "pass either --instance-type with --shard-count (explicit) \
-                 or --capacity-gb (managed)",
+                 or --capacity-gib (managed)",
             ));
         }
     };
@@ -149,14 +149,14 @@ pub fn determine_provisioning_update(
     instance_type: Option<String>,
     shard_count: Option<u32>,
     replicas_per_shard: Option<Bounds>,
-    capacity_gb: Option<Bounds>,
+    capacity_gib: Option<Bounds>,
     zones: Vec<String>,
 ) -> Result<CapacityPoolProvisioningUpdate, CliError> {
     let update = match mode {
         CapacityPoolProvisioningMode::Explicit => {
-            if capacity_gb.is_some() {
+            if capacity_gib.is_some() {
                 return Err(CliError::new(
-                    "--capacity-gb is a managed-mode field; pass --mode managed",
+                    "--capacity-gib is a managed-mode field; pass --mode managed",
                 ));
             }
             let replicas_per_shard = replicas_per_shard.map(pinned).transpose()?;
@@ -175,7 +175,7 @@ pub fn determine_provisioning_update(
                 ));
             }
             CapacityPoolProvisioningUpdate::Managed {
-                capacity: capacity_gb.map(CapacityBounds::from),
+                capacity: capacity_gib.map(CapacityBounds::from),
                 replication: replicas_per_shard.map(ReplicationBounds::from),
                 zones,
             }

--- a/momento/src/commands/cloud_linter/utils.rs
+++ b/momento/src/commands/cloud_linter/utils.rs
@@ -40,12 +40,6 @@ where
     }
 }
 
-impl From<serde_json::Error> for CliError {
-    fn from(val: serde_json::Error) -> Self {
-        CliError::new(format!("{val:?}"))
-    }
-}
-
 impl From<std::io::Error> for CliError {
     fn from(val: std::io::Error) -> Self {
         CliError::new(format!("{val:?}"))

--- a/momento/src/commands/database/database_cli.rs
+++ b/momento/src/commands/database/database_cli.rs
@@ -1,9 +1,8 @@
-use super::utils::{DatabaseError, DatabaseResponse};
+use super::utils::call_database_api;
+use crate::commands::utils::MomentoHttpResponse::{Parsed, Unparseable};
 use crate::{error::CliError, utils::console::console_data};
 
 use http::Method;
-use log::{info, warn};
-use reqwest;
 use serde_json;
 
 pub async fn create_database(
@@ -12,53 +11,27 @@ pub async fn create_database(
     pool_name: String,
     database_name: String,
 ) -> Result<(), CliError> {
-    let request_url = format!("{endpoint}/database/{database_name}");
-    let data = serde_json::json!({
-        "pool_name": pool_name
-    })
-    .to_string();
-
-    let req_client = reqwest::Client::builder().build()?;
-    let response = req_client
-        .request(Method::POST, &request_url)
-        .body(data)
-        .header("authorization", &auth_token)
-        .header("content-type", "application/json")
-        .send()
-        .await?;
-    let status = response.status();
-    if status.is_success() {
-        let response_text = response.text().await?;
-        match serde_json::from_str::<DatabaseResponse>(response_text.as_str()) {
-            Ok(database) => {
-                info!("Response sent back by {database_name} database creation:\n{database:#?}");
-                console_data!(
-                    "Database created! Name: {}, Pool: {}",
-                    database.name,
-                    database.pool_name
-                );
-            }
-            Err(err) => {
-                warn!(
-                    "Can't parse response from {database_name} database creation:\n{response_text}\n{err}"
-                );
-                console_data!("Database created! {response_text}");
-            }
-        };
-        Ok(())
-    } else {
-        let error_text = response.text().await?;
-        Err(CliError::new(if error_text.is_empty() {
-            format!("{status}")
-        } else {
-            let error_message = match serde_json::from_str::<DatabaseError>(error_text.as_str()) {
-                Ok(error) => error
-                    .detail
-                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
-                Err(_) => error_text.clone(),
-            };
-            format!("{status}: {error_message}")
-        })
-        .with_details(error_text))
-    }
+    match call_database_api(
+        Method::POST,
+        endpoint,
+        auth_token,
+        database_name,
+        Some(serde_json::json!({
+            "pool_name": pool_name
+        })),
+    )
+    .await?
+    {
+        Parsed(database) => {
+            console_data!(
+                "Creating database! Name: {}, Pool: {}",
+                database.name,
+                database.pool_name,
+            );
+        }
+        Unparseable(response_text) => {
+            console_data!("Creating database! {response_text}");
+        }
+    };
+    Ok(())
 }

--- a/momento/src/commands/database/database_cli.rs
+++ b/momento/src/commands/database/database_cli.rs
@@ -10,9 +10,9 @@ pub async fn create_database(
     endpoint: String,
     auth_token: String,
     pool_name: String,
-    name: String,
+    database_name: String,
 ) -> Result<(), CliError> {
-    let request_url = format!("{endpoint}/database/{name}");
+    let request_url = format!("{endpoint}/database/{database_name}");
     let data = serde_json::json!({
         "pool_name": pool_name
     })
@@ -31,7 +31,7 @@ pub async fn create_database(
         let response_text = response.text().await?;
         match serde_json::from_str::<DatabaseResponse>(response_text.as_str()) {
             Ok(database) => {
-                info!("Response sent back by {name} database creation:\n{database:#?}");
+                info!("Response sent back by {database_name} database creation:\n{database:#?}");
                 console_data!(
                     "Database created! Name: {}, Pool: {}",
                     database.name,
@@ -40,7 +40,7 @@ pub async fn create_database(
             }
             Err(err) => {
                 warn!(
-                    "Can't parse response from {name} database creation:\n{response_text}\n{err}"
+                    "Can't parse response from {database_name} database creation:\n{response_text}\n{err}"
                 );
                 console_data!("Database created! {response_text}");
             }

--- a/momento/src/commands/database/database_cli.rs
+++ b/momento/src/commands/database/database_cli.rs
@@ -1,0 +1,64 @@
+use super::utils::{DatabaseError, DatabaseResponse};
+use crate::{error::CliError, utils::console::console_data};
+
+use http::Method;
+use log::{info, warn};
+use reqwest;
+use serde_json;
+
+pub async fn create_database(
+    endpoint: String,
+    auth_token: String,
+    pool_name: String,
+    name: String,
+) -> Result<(), CliError> {
+    let request_url = format!("{endpoint}/database/{name}");
+    let data = serde_json::json!({
+        "pool_name": pool_name
+    })
+    .to_string();
+
+    let req_client = reqwest::Client::builder().build()?;
+    let response = req_client
+        .request(Method::POST, &request_url)
+        .body(data)
+        .header("authorization", &auth_token)
+        .header("content-type", "application/json")
+        .send()
+        .await?;
+    let status = response.status();
+    if status.is_success() {
+        let response_text = response.text().await?;
+        match serde_json::from_str::<DatabaseResponse>(response_text.as_str()) {
+            Ok(database) => {
+                info!("Response sent back by {name} database creation:\n{database:#?}");
+                console_data!(
+                    "Database created! Name: {}, Pool: {}",
+                    database.name,
+                    database.pool_name
+                );
+            }
+            Err(err) => {
+                warn!(
+                    "Can't parse response from {name} database creation:\n{response_text}\n{err}"
+                );
+                console_data!("Database created! {response_text}");
+            }
+        };
+        Ok(())
+    } else {
+        let error_text = response.text().await?;
+        Err(CliError::new(if error_text.is_empty() {
+            format!("{status}")
+        } else {
+            let error_message = match serde_json::from_str::<DatabaseError>(error_text.as_str()) {
+                Ok(error) => error
+                    .detail
+                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
+                Err(_) => error_text.clone(),
+            };
+            format!("{status}: {error_message}")
+        })
+        .with_details(error_text))
+    }
+}

--- a/momento/src/commands/database/database_cli.rs
+++ b/momento/src/commands/database/database_cli.rs
@@ -25,7 +25,7 @@ pub async fn create_database(
     {
         Parsed(database) => {
             console_data!(
-                "Creating database! Name: {}, Pool: {}",
+                "Creating database! Name: {}, Capacity Pool: {}",
                 database.name,
                 database.pool_name,
             );
@@ -42,8 +42,9 @@ pub async fn delete_database(
     auth_token: String,
     database_name: String,
 ) -> Result<(), CliError> {
-    let response_text = call_database_delete_api(endpoint, auth_token, database_name).await?;
-    console_data!("Deleting database! {response_text}");
+    let response_text =
+        call_database_delete_api(endpoint, auth_token, database_name.clone()).await?;
+    console_data!("Deleting database {database_name}! {response_text}");
     Ok(())
 }
 
@@ -58,7 +59,11 @@ pub async fn list_databases(endpoint: String, auth_token: String) -> Result<(), 
             } else {
                 console_data!("Databases:");
                 databases_list.iter().for_each(|database| {
-                    console_data!("\nName: {}, Pool: {}", database.name, database.pool_name);
+                    console_data!(
+                        "\nName: {}, Capacity Pool: {}",
+                        database.name,
+                        database.pool_name
+                    );
                 });
             }
         }

--- a/momento/src/commands/database/database_cli.rs
+++ b/momento/src/commands/database/database_cli.rs
@@ -1,4 +1,5 @@
-use super::utils::call_database_api;
+use super::utils::{call_database_api, call_database_delete_api, call_database_list_api};
+use crate::commands::database::utils::ListDatabasesResponse;
 use crate::commands::utils::MomentoHttpResponse::{Parsed, Unparseable};
 use crate::{error::CliError, utils::console::console_data};
 
@@ -31,6 +32,38 @@ pub async fn create_database(
         }
         Unparseable(response_text) => {
             console_data!("Creating database! {response_text}");
+        }
+    };
+    Ok(())
+}
+
+pub async fn delete_database(
+    endpoint: String,
+    auth_token: String,
+    database_name: String,
+) -> Result<(), CliError> {
+    let response_text = call_database_delete_api(endpoint, auth_token, database_name).await?;
+    console_data!("Deleting database! {response_text}");
+    Ok(())
+}
+
+pub async fn list_databases(endpoint: String, auth_token: String) -> Result<(), CliError> {
+    let response = call_database_list_api(endpoint, auth_token).await?;
+    match response {
+        Parsed(ListDatabasesResponse {
+            databases: databases_list,
+        }) => {
+            if databases_list.is_empty() {
+                console_data!("No databases found");
+            } else {
+                console_data!("Databases:");
+                databases_list.iter().for_each(|database| {
+                    console_data!("\nName: {}, Pool: {}", database.name, database.pool_name);
+                });
+            }
+        }
+        Unparseable(response_text) => {
+            console_data!("Listing databases:\n{response_text}");
         }
     };
     Ok(())

--- a/momento/src/commands/database/mod.rs
+++ b/momento/src/commands/database/mod.rs
@@ -1,0 +1,2 @@
+pub mod database_cli;
+mod utils;

--- a/momento/src/commands/database/utils.rs
+++ b/momento/src/commands/database/utils.rs
@@ -1,3 +1,7 @@
+use crate::commands::utils::{call_momento_http_api, MomentoHttpData, MomentoHttpResponse};
+
+use crate::error::CliError;
+use http::Method;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -6,8 +10,19 @@ pub struct DatabaseResponse {
     pub pool_name: String,
 }
 
-#[derive(Deserialize)]
-pub struct DatabaseError {
-    pub detail: Option<String>,
-    pub message: Option<String>,
+pub async fn call_database_api(
+    method: Method,
+    endpoint: String,
+    auth_token: String,
+    database_name: String,
+    data: Option<serde_json::Value>,
+) -> Result<MomentoHttpResponse<DatabaseResponse>, CliError> {
+    call_momento_http_api(
+        method,
+        format!("{endpoint}/database/{database_name}"),
+        auth_token,
+        None,
+        data.map(MomentoHttpData::Json),
+    )
+    .await
 }

--- a/momento/src/commands/database/utils.rs
+++ b/momento/src/commands/database/utils.rs
@@ -1,0 +1,13 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct DatabaseResponse {
+    pub name: String,
+    pub pool_name: String,
+}
+
+#[derive(Deserialize)]
+pub struct DatabaseError {
+    pub detail: Option<String>,
+    pub message: Option<String>,
+}

--- a/momento/src/commands/database/utils.rs
+++ b/momento/src/commands/database/utils.rs
@@ -1,4 +1,6 @@
-use crate::commands::utils::{call_momento_http_api, MomentoHttpData, MomentoHttpResponse};
+use crate::commands::utils::{
+    call_momento_http_api, call_momento_http_api_raw, MomentoHttpData, MomentoHttpResponse,
+};
 
 use crate::error::CliError;
 use http::Method;
@@ -10,6 +12,18 @@ pub struct DatabaseResponse {
     pub pool_name: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ListDatabasesResponse {
+    pub databases: Vec<DatabaseResponse>,
+}
+
+fn build_request_url(endpoint: String, database_name: Option<String>) -> String {
+    match database_name {
+        None => format!("{endpoint}/database"),
+        Some(name) => format!("{endpoint}/database/{name}"),
+    }
+}
+
 pub async fn call_database_api(
     method: Method,
     endpoint: String,
@@ -19,10 +33,39 @@ pub async fn call_database_api(
 ) -> Result<MomentoHttpResponse<DatabaseResponse>, CliError> {
     call_momento_http_api(
         method,
-        format!("{endpoint}/database/{database_name}"),
+        build_request_url(endpoint, Some(database_name)),
         auth_token,
         None,
         data.map(MomentoHttpData::Json),
+    )
+    .await
+}
+
+pub async fn call_database_delete_api(
+    endpoint: String,
+    auth_token: String,
+    database_name: String,
+) -> Result<String, CliError> {
+    call_momento_http_api_raw(
+        Method::DELETE,
+        build_request_url(endpoint, Some(database_name)),
+        auth_token,
+        None,
+        None,
+    )
+    .await
+}
+
+pub async fn call_database_list_api(
+    endpoint: String,
+    auth_token: String,
+) -> Result<MomentoHttpResponse<ListDatabasesResponse>, CliError> {
+    call_momento_http_api(
+        Method::GET,
+        build_request_url(endpoint, None),
+        auth_token,
+        None,
+        None,
     )
     .await
 }

--- a/momento/src/commands/functions/function_cli.rs
+++ b/momento/src/commands/functions/function_cli.rs
@@ -9,8 +9,8 @@ use momento::{
 
 use crate::{
     commands::functions::utils::{
-        build_invocation_headers, build_invocation_url, format_metrics_config, read_wasm_file,
-        InvocationOptions,
+        build_invocation_headers, build_invocation_path, call_function_api, format_metrics_config,
+        read_wasm_file, InvocationOptions,
     },
     error::CliError,
     utils::console::console_data,
@@ -18,16 +18,7 @@ use crate::{
 
 use http::Method;
 use log::info;
-use reqwest;
-use serde::Deserialize;
-use serde_json;
 use std::str::FromStr; // to use http::Method::from_str
-
-#[derive(Deserialize)]
-struct InvokeError {
-    detail: Option<String>,
-    message: Option<String>,
-}
 
 pub async fn put_function(
     client: FunctionClient,
@@ -130,40 +121,20 @@ pub async fn invoke_function(
     if !headers.is_empty() {
         info!("with headers:\n{headers:#?}");
     }
-
-    let request_url = build_invocation_url(endpoint, cache_name, name.clone(), options.path)?;
-    info!("at URL: {request_url}");
-
     info!("with request method: {method}");
 
-    let req_client = reqwest::Client::builder().build()?;
-    let response = req_client
-        .request(Method::from_str(&method)?, &request_url)
-        .body(data)
-        .header("authorization", &auth_token)
-        .headers(headers)
-        .send()
-        .await?;
-    info!("Headers sent back by {name}:\n{:#?}", response.headers());
-    let status = response.status();
-    if status.is_success() {
-        console_data!("{}", response.text().await?);
-        Ok(())
-    } else {
-        let error_text = response.text().await?;
-        Err(CliError::new(if error_text.is_empty() {
-            format!("{status}")
-        } else {
-            let error_message = match serde_json::from_str::<InvokeError>(error_text.as_str()) {
-                Ok(error_json) => error_json
-                    .detail
-                    .unwrap_or(error_json.message.unwrap_or(error_text.clone())),
-                Err(_) => error_text.clone(),
-            };
-            format!("{status}: {error_message}")
-        })
-        .with_details(error_text))
-    }
+    let full_path = build_invocation_path(cache_name, name, options.path)?;
+    let response_text = call_function_api(
+        Method::from_str(&method)?,
+        endpoint,
+        auth_token,
+        full_path,
+        headers,
+        data,
+    )
+    .await?;
+    console_data!("{response_text}");
+    Ok(())
 }
 
 pub async fn list_functions(client: FunctionClient, cache_name: String) -> Result<(), CliError> {

--- a/momento/src/commands/functions/utils.rs
+++ b/momento/src/commands/functions/utils.rs
@@ -1,16 +1,16 @@
-use std::collections::HashMap;
-use std::fs;
-use std::str::FromStr; // to use HeaderName::from_str
+use crate::commands::utils::{call_momento_http_api_raw, MomentoHttpData};
+use crate::error::CliError;
 
 use momento::functions::{
     CurrentFunctionVersion, FunctionMetricsConfig, FunctionMetricsConfigChange, WasmSource,
 };
 
-use crate::error::CliError;
-
 use form_urlencoded;
-use http::method::InvalidMethod;
+use http::{method::InvalidMethod, Method};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderName, InvalidHeaderValue};
+use std::collections::HashMap;
+use std::fs;
+use std::str::FromStr; // to use HeaderName::from_str
 
 /// put-function
 pub fn read_wasm_file(wasm_file: String) -> Result<Vec<u8>, CliError> {
@@ -128,15 +128,13 @@ pub fn build_invocation_headers(headers_str: &str) -> Result<HeaderMap, CliError
     Ok(headers)
 }
 
-pub fn build_invocation_url(
-    endpoint: String,
+pub fn build_invocation_path(
     cache_name: String,
-    name: String,
+    function_name: String,
     path: Option<String>,
 ) -> Result<String, CliError> {
-    let function_url = format!("{endpoint}/functions/{cache_name}/{name}");
-    let request_url = match path {
-        None => function_url,
+    let path = match path {
+        None => format!("{cache_name}/{function_name}"),
         Some(path) => {
             let query_string = path.split_once('?').unwrap_or_default().1;
             if form_urlencoded::parse(query_string.as_bytes()).any(|(key, _)| key == "token") {
@@ -144,16 +142,31 @@ pub fn build_invocation_url(
                     "To use a specific Momento API key, please specify --profile or --api-key, not the 'token' query parameter",
                 ));
             }
-            format!("{function_url}/{}", path.trim_start_matches("/"))
+            format!(
+                "{cache_name}/{function_name}/{}",
+                path.trim_start_matches("/")
+            )
         }
     };
-    Ok(request_url)
+    Ok(path)
 }
 
-impl From<reqwest::Error> for CliError {
-    fn from(e: reqwest::Error) -> Self {
-        CliError::new(format!("{e} (reqwest error)")).with_details(format!("{e:#?}"))
-    }
+pub async fn call_function_api(
+    method: Method,
+    endpoint: String,
+    auth_token: String,
+    full_path: String,
+    headers: reqwest::header::HeaderMap,
+    data: String,
+) -> Result<String, CliError> {
+    call_momento_http_api_raw(
+        method,
+        format!("{endpoint}/functions/{full_path}"),
+        auth_token,
+        Some(headers),
+        Some(MomentoHttpData::String(data)),
+    )
+    .await
 }
 
 impl From<InvalidMethod> for CliError {

--- a/momento/src/commands/mod.rs
+++ b/momento/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod configure;
 pub mod database;
 pub mod functions;
 pub mod topic;
+pub mod utils;

--- a/momento/src/commands/mod.rs
+++ b/momento/src/commands/mod.rs
@@ -1,6 +1,8 @@
 pub mod account;
 pub mod cache;
+pub mod capacity_pool;
 pub mod cloud_linter;
 pub mod configure;
+pub mod database;
 pub mod functions;
 pub mod topic;

--- a/momento/src/commands/utils.rs
+++ b/momento/src/commands/utils.rs
@@ -1,0 +1,134 @@
+use crate::error::CliError;
+
+use http::Method;
+use log::{info, warn};
+use reqwest;
+use serde::{de::DeserializeOwned, Deserialize};
+use std::fmt::Debug;
+
+pub enum MomentoHttpData {
+    Json(serde_json::Value),
+    String(String),
+}
+
+#[derive(Deserialize)]
+struct MomentoHttpError {
+    pub detail: Option<String>,
+    pub message: Option<String>,
+}
+
+pub enum MomentoHttpResponse<T> {
+    Parsed(T),
+    Unparseable(String),
+}
+
+async fn call_api(
+    method: Method,
+    request_url: String,
+    auth_token: String,
+    headers: Option<reqwest::header::HeaderMap>,
+    data: Option<MomentoHttpData>,
+) -> Result<String, CliError> {
+    let req_client = reqwest::Client::builder().build()?;
+    let request_builder = req_client
+        .request(method.clone(), &request_url)
+        .header("authorization", &auth_token);
+    let request_builder = match data {
+        None => request_builder,
+        Some(MomentoHttpData::Json(data)) => request_builder
+            .body(data.to_string())
+            .header("content-type", "application/json"),
+        Some(MomentoHttpData::String(data)) => request_builder.body(data),
+    };
+    let request_builder = match headers {
+        None => request_builder,
+        Some(mut headers) => {
+            if headers.remove("authorization").is_some() {
+                warn!("Removed authorization header; must be specified via --profile or --api-key");
+            }
+            request_builder.headers(headers)
+        }
+    };
+
+    let response = request_builder.send().await?;
+    let status = response.status();
+
+    info!(
+        "Headers sent back from {method} {request_url}:\n{:#?}",
+        response.headers()
+    );
+
+    if status.is_success() {
+        Ok(response.text().await?)
+    } else {
+        let error_text = response.text().await?;
+        Err(CliError::new(if error_text.is_empty() {
+            format!("{status}")
+        } else {
+            let error_message = match serde_json::from_str::<MomentoHttpError>(error_text.as_str())
+            {
+                Ok(error) => error
+                    .detail
+                    .unwrap_or(error.message.unwrap_or(error_text.clone())),
+                Err(_) => error_text.clone(),
+            };
+            format!("{status}: {error_message}")
+        })
+        .with_details(error_text))
+    }
+}
+
+pub async fn call_momento_http_api_raw(
+    method: Method,
+    request_url: String,
+    auth_token: String,
+    headers: Option<reqwest::header::HeaderMap>,
+    data: Option<MomentoHttpData>,
+) -> Result<String, CliError> {
+    let response_text = call_api(
+        method.clone(),
+        request_url.clone(),
+        auth_token,
+        headers,
+        data,
+    )
+    .await?;
+    info!("Response sent back from {method} {request_url}:\n{response_text}");
+    Ok(response_text)
+}
+
+pub async fn call_momento_http_api<T: DeserializeOwned + Debug>(
+    method: Method,
+    request_url: String,
+    auth_token: String,
+    headers: Option<reqwest::header::HeaderMap>,
+    data: Option<MomentoHttpData>,
+) -> Result<MomentoHttpResponse<T>, CliError> {
+    let response_text = call_api(
+        method.clone(),
+        request_url.clone(),
+        auth_token,
+        headers,
+        data,
+    )
+    .await?;
+    match serde_json::from_str::<T>(response_text.as_str()) {
+        Ok(response) => {
+            info!("Response sent back from {method} {request_url}:\n{response:#?}");
+            Ok(MomentoHttpResponse::Parsed(response))
+        }
+        Err(err) => {
+            warn!(
+                "Can't parse response from {method} {request_url}: \
+                \n{response_text}\n{err}"
+            );
+            Ok(MomentoHttpResponse::Unparseable(response_text))
+        }
+    }
+}
+
+impl From<reqwest::Error> for CliError {
+    fn from(e: reqwest::Error) -> Self {
+        CliError::new(format!("{e} (reqwest error)")).with_details(format!("{e:#?}"))
+    }
+}

--- a/momento/src/error/mod.rs
+++ b/momento/src/error/mod.rs
@@ -26,6 +26,12 @@ impl fmt::Display for CliError {
     }
 }
 
+impl From<serde_json::Error> for CliError {
+    fn from(val: serde_json::Error) -> Self {
+        CliError::new(format!("{val:?}"))
+    }
+}
+
 impl CliError {
     pub fn new(msg: impl Into<String>) -> Self {
         Self {

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -419,6 +419,18 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         )
                         .await?
                     }
+                    momento_cli_opts::CapacityPoolCommand::DeletePool { name } => {
+                        commands::capacity_pool::pool_cli::delete_pool(
+                            api_endpoint,
+                            auth_token,
+                            name,
+                        )
+                        .await?
+                    }
+                    momento_cli_opts::CapacityPoolCommand::ListPools {} => {
+                        commands::capacity_pool::pool_cli::list_pools(api_endpoint, auth_token)
+                            .await?
+                    }
                 }
             }
             PreviewCommand::Database {
@@ -444,6 +456,18 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                             database_name,
                         )
                         .await?
+                    }
+                    momento_cli_opts::DatabaseCommand::DeleteDatabase { database_name } => {
+                        commands::database::database_cli::delete_database(
+                            api_endpoint,
+                            auth_token,
+                            database_name,
+                        )
+                        .await?
+                    }
+                    momento_cli_opts::DatabaseCommand::ListDatabases {} => {
+                        commands::database::database_cli::list_databases(api_endpoint, auth_token)
+                            .await?
                     }
                 }
             }

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -14,6 +14,7 @@ use utils::{
 };
 
 use crate::{
+    commands::capacity_pool::utils::{determine_provisioning, determine_provisioning_update},
     commands::functions::utils::{
         determine_current_function_version, determine_metrics_config_change, determine_wasm_source,
         InvocationOptions,
@@ -367,16 +368,21 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         instance_type,
                         shard_count,
                         replicas_per_shard,
+                        capacity_gb,
                         zones,
                     } => {
+                        let provisioning = determine_provisioning(
+                            instance_type,
+                            shard_count,
+                            replicas_per_shard,
+                            capacity_gb,
+                            zones,
+                        )?;
                         commands::capacity_pool::pool_cli::create_pool(
                             api_endpoint,
                             auth_token,
                             name,
-                            instance_type,
-                            shard_count,
-                            replicas_per_shard,
-                            zones,
+                            provisioning,
                         )
                         .await?
                     }
@@ -390,19 +396,26 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                     }
                     momento_cli_opts::CapacityPoolCommand::UpdatePool {
                         name,
+                        mode,
                         instance_type,
                         shard_count,
                         replicas_per_shard,
+                        capacity_gb,
                         zones,
                     } => {
+                        let provisioning_update = determine_provisioning_update(
+                            mode,
+                            instance_type,
+                            shard_count,
+                            replicas_per_shard,
+                            capacity_gb,
+                            zones,
+                        )?;
                         commands::capacity_pool::pool_cli::update_pool(
                             api_endpoint,
                             auth_token,
                             name,
-                            instance_type,
-                            shard_count,
-                            replicas_per_shard,
-                            zones,
+                            provisioning_update,
                         )
                         .await?
                     }

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -350,6 +350,87 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                     }
                 }
             }
+            PreviewCommand::Pool {
+                api_key,
+                endpoint,
+                operation,
+            } => {
+                let (creds, _) = get_creds_and_config(&args.profile).await?;
+                let credential_provider = creds.override_and_authenticate(api_key, endpoint)?;
+
+                let api_endpoint = credential_provider.cache_http_endpoint().to_string();
+                let auth_token = credential_provider.auth_token().to_string();
+
+                match operation {
+                    momento_cli_opts::PoolCommand::CreatePool {
+                        name,
+                        instance_type,
+                        shard_count,
+                        replicas_per_shard,
+                        zones,
+                    } => {
+                        commands::capacity_pool::pool_cli::create_pool(
+                            api_endpoint,
+                            auth_token,
+                            name,
+                            instance_type,
+                            shard_count,
+                            replicas_per_shard,
+                            zones,
+                        )
+                        .await?
+                    }
+                    momento_cli_opts::PoolCommand::GetStatus { name } => {
+                        commands::capacity_pool::pool_cli::get_status(
+                            api_endpoint,
+                            auth_token,
+                            name,
+                        )
+                        .await?
+                    }
+                    momento_cli_opts::PoolCommand::UpdatePool {
+                        name,
+                        instance_type,
+                        shard_count,
+                        replicas_per_shard,
+                        zones,
+                    } => {
+                        commands::capacity_pool::pool_cli::update_pool(
+                            api_endpoint,
+                            auth_token,
+                            name,
+                            instance_type,
+                            shard_count,
+                            replicas_per_shard,
+                            zones,
+                        )
+                        .await?
+                    }
+                }
+            }
+            PreviewCommand::Database {
+                api_key,
+                endpoint,
+                operation,
+            } => {
+                let (creds, _) = get_creds_and_config(&args.profile).await?;
+                let credential_provider = creds.override_and_authenticate(api_key, endpoint)?;
+
+                let api_endpoint = credential_provider.cache_http_endpoint().to_string();
+                let auth_token = credential_provider.auth_token().to_string();
+
+                match operation {
+                    momento_cli_opts::DatabaseCommand::CreateDatabase { pool_name, name } => {
+                        commands::database::database_cli::create_database(
+                            api_endpoint,
+                            auth_token,
+                            pool_name,
+                            name,
+                        )
+                        .await?
+                    }
+                }
+            }
         },
     }
     Ok(())

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -362,7 +362,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 let auth_token = credential_provider.auth_token().to_string();
 
                 match operation {
-                    momento_cli_opts::PoolCommand::CreatePool {
+                    momento_cli_opts::CapacityPoolCommand::CreatePool {
                         name,
                         instance_type,
                         shard_count,
@@ -380,7 +380,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         )
                         .await?
                     }
-                    momento_cli_opts::PoolCommand::GetStatus { name } => {
+                    momento_cli_opts::CapacityPoolCommand::GetStatus { name } => {
                         commands::capacity_pool::pool_cli::get_status(
                             api_endpoint,
                             auth_token,
@@ -388,7 +388,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         )
                         .await?
                     }
-                    momento_cli_opts::PoolCommand::UpdatePool {
+                    momento_cli_opts::CapacityPoolCommand::UpdatePool {
                         name,
                         instance_type,
                         shard_count,
@@ -420,12 +420,15 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                 let auth_token = credential_provider.auth_token().to_string();
 
                 match operation {
-                    momento_cli_opts::DatabaseCommand::CreateDatabase { pool_name, name } => {
+                    momento_cli_opts::DatabaseCommand::CreateDatabase {
+                        pool_name,
+                        database_name,
+                    } => {
                         commands::database::database_cli::create_database(
                             api_endpoint,
                             auth_token,
                             pool_name,
-                            name,
+                            database_name,
                         )
                         .await?
                     }

--- a/momento/src/main.rs
+++ b/momento/src/main.rs
@@ -368,14 +368,14 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         instance_type,
                         shard_count,
                         replicas_per_shard,
-                        capacity_gb,
+                        capacity_gib,
                         zones,
                     } => {
                         let provisioning = determine_provisioning(
                             instance_type,
                             shard_count,
                             replicas_per_shard,
-                            capacity_gb,
+                            capacity_gib,
                             zones,
                         )?;
                         commands::capacity_pool::pool_cli::create_pool(
@@ -400,7 +400,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                         instance_type,
                         shard_count,
                         replicas_per_shard,
-                        capacity_gb,
+                        capacity_gib,
                         zones,
                     } => {
                         let provisioning_update = determine_provisioning_update(
@@ -408,7 +408,7 @@ async fn run_momento_command(args: momento_cli_opts::Momento) -> Result<(), CliE
                             instance_type,
                             shard_count,
                             replicas_per_shard,
-                            capacity_gb,
+                            capacity_gib,
                             zones,
                         )?;
                         commands::capacity_pool::pool_cli::update_pool(


### PR DESCRIPTION
The CLI now supports:
- `create` capacity pool or Momento database
- `update` capacity pool
- `get-status` of capacity pool (creating|active|deleting)
- `delete` capacity pool or database
- `list` all capacity pools (including provisioning & active diagnostics) or databases

As usual, `--help` text is available for all commands & options, and `--verbose` logs more details like response headers and additional response body fields.

## Sample Usage

```sh
cargo run -q -- preview pool create-pool --name cli-test-explicit \
  --instance-type t4g.medium --shard-count 1 \
  --zones usw2-az1,usw2-az2 --replicas-per-shard 0
# Creating capacity pool! Name: cli-test-explicit, Status: creating, Provisioning: {
#   "explicit": {
#     "instance_type": "t4g.medium",
#     "shard_count": 1,
#     "replicas_per_shard": 0,
#     "zones": [
#       "usw2-az1",
#       "usw2-az2"
#     ]
#   }
# }

cargo run -q -- preview pool get-status --name cli-test-explicit
# Capacity pool status for cli-test-explicit: creating

cargo run -q -- preview pool get-status --name cli-test-explicit
# Capacity pool status for cli-test-explicit: active

cargo run -q -- preview database create-database \
  --database-name cli-test-db --pool-name cli-test-explicit
# Creating database! Name: cli-test-db, Capacity Pool: cli-test-explicit

cargo run -q -- preview pool update-pool --name cli-test-explicit \
  --mode explicit --shard-count 3 --zones usw2-az2
# Updating capacity pool! Name: cli-test-explicit, Status: active, Provisioning: {
#   "explicit": {
#     "instance_type": "t4g.medium",
#     "shard_count": 3,
#     "replicas_per_shard": 0,
#     "zones": [
#       "usw2-az2"
#     ]
#   }
# }

cargo run -q -- preview pool update-pool --name cli-test-explicit \
  --mode explicit --shard-count 2
# Updating capacity pool! Name: cli-test-explicit, Status: active, Provisioning: {
#   "explicit": {
#     "instance_type": "t4g.medium",
#     "shard_count": 2,
#     "replicas_per_shard": 0,
#     "zones": [
#       "usw2-az2"
#     ]
#   }
# }
```

Managed provisioning:
```sh
cargo run -q -- preview pool create-pool -n cli-test-managed \
  --capacity-gib 2  --zones usw2-az1 --replicas-per-shard 0..5
# Creating capacity pool! Name: cli-test-managed, Status: creating, Provisioning: {
#   "managed": {
#     "capacity": {
#       "min_gib": 2,
#       "max_gib": 2
#     },
#     "replication": {
#       "min_replicas_per_shard": 0,
#       "max_replicas_per_shard": 5
#     },
#     "zones": [
#       "usw2-az1"
#     ]
#   }
# }

cargo run -q -- preview pool update-pool -n cli-test-managed \
  --mode managed --capacity-gib 5 --zones usw2-az3,usw2-az2
# Updating capacity pool! Name: cli-test-managed, Status: creating, Provisioning: {
#   "managed": {
#     "capacity": {
#       "min_gib": 5,
#       "max_gib": 5
#     },
#     "replication": {
#       "min_replicas_per_shard": 0,
#       "max_replicas_per_shard": 5
#     },
#     "zones": [
#       "usw2-az3",
#       "usw2-az2"
#     ]
#   }
# }
```

List:
```sh
cargo run -q -- preview pool list-pools
# Capacity pools:
# 
# Name: cli-test-managed, Status: active, Provisioning: {
#   "managed": {
#     "capacity": {
#       "min_gib": 5,
#       "max_gib": 5
#     },
#     "replication": {
#       "min_replicas_per_shard": 0,
#       "max_replicas_per_shard": 5
#     },
#     "zones": [
#       "usw2-az3",
#       "usw2-az2"
#     ]
#   }
# }, Diagnostics: []
# 
# Name: cli-test-explicit, Status: active, Provisioning: {
#   "explicit": {
#     "instance_type": "t4g.medium",
#     "shard_count": 2,
#     "replicas_per_shard": 0,
#     "zones": [
#       "usw2-az2"
#     ]
#   }
}, Diagnostics: []

cargo run -q -- preview database list-databases
# Databases:
# 
# Name: cli-test-db, Capacity Pool: cli-test-explicit
```

Delete:
```sh
cargo run -q -- preview database delete-database -n cli-test-db
# Deleting database cli-test-db!

cargo run -q -- preview pool delete-pool -n cli-test-explicit
# Deleting capacity pool cli-test-explicit!

cargo run -q -- preview pool delete-pool -n cli-test-managed
# Deleting capacity pool cli-test-managed!

cargo run -q -- preview pool get-status -n cli-test-managed
# Capacity pool status for cli-test-managed: deleting

cargo run -q -- preview pool list-pools
# No capacity pools found
```

## Sample Errors

```sh
cargo run -q -- preview pool get-status --name cli-test-error
# ERROR: 404 Not Found: capacity pool 'cli-test-error' doesn't exist for account 'a-abcdefg'

cargo run -q -- preview pool create-pool --name cli-test-error \
  --shard-count 0
# error: invalid value '0' for '--shard-count <SHARD_COUNT>': 0 is not in 1..=4294967295

cargo run -q -- preview pool create-pool --name cli-test-error \
  --capacity-gib 0..3
# error: invalid value '0..3' for '--capacity-gib <CAPACITY_GIB>': bounds must be at least 1

cargo run -q -- preview pool create-pool --name cli-test-error \
  --instance-type t4g.medium --shard-count 1 --replicas-per-shard 0 \
  --zones us-west-2-all
# ERROR: 400 Bad Request: Invalid Argument for field 'provisioning.zones': Invalid availability zone 'us-west-2-all'. Valid availability zones are: usw2-az1, usw2-az2, usw2-az3, usw2-az4
```